### PR TITLE
V2.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Node to Python", 
     "description": "Convert Blender node groups to a Python add-on!",
     "author": "Brendan Parmer",
-    "version": (2, 0, 1),
+    "version": (2, 1, 0),
     "blender": (3, 0, 0),
     "location": "Node", 
     "category": "Node",

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,21 +7,19 @@
 ## About
 A Blender add-on to create add-ons! This add-on will take your Geometry Nodes or Materials and convert them into legible Python add-ons!
 
-It automatically handles node layout, default values, subgroups, naming, colors, and more! 
+Node To Python automatically handles node layout, default values, subgroups, naming, colors, and more! 
 
-I think Blender's node-based editors are powerful, yet accessible tools, and I wanted to make scripting them easier for add-on creators. Combining Python with node based setups allows you to do things that would otherwise be tedious or impossible, such as
+Blender's node-based editors are powerful, yet accessible tools, and I wanted to make scripting them easier for add-on creators. Combining Python with node based setups allows you to do things that would otherwise be tedious or impossible, such as
 * `for` loops
 * creating different node trees for different versions or settings
 * interfacing with other parts of the software or properties of an object
 
-NodeToPython recreates the node networks for you, so you can focus on the good stuff. 
-
 ## Supported Versions
-NodeToPython v2.0 is compatible with Blender 3.0 - 3.4 on Windows, macOS, and Linux. I generally try to update the addon to handle new nodes around the beta release of each update.
+NodeToPython v2.1 is compatible with Blender 3.0 - 3.6 on Windows, macOS, and Linux. I generally try to update the add-on to handle new nodes around the beta release of each update.
 
 ## Installation
 1. Download the `NodeToPython.zip` file from the [latest release](https://github.com/BrendanParmer/NodeToPython/releases)
-    * If you download other options, you'll need to rename the zip and the first folder to "NodeToPython" so Blender can properly import the module
+    * If you clone the repository or download other options, you'll need to rename the zip and the first folder to "NodeToPython" so Blender can properly import the add-on
 2. In Blender, navigate to `Edit > Preferences > Add-ons`
 3. Click Install, and find where you downloaded the zip file. Then hit the `Install Add-on` button, and you're done!
 
@@ -37,19 +35,26 @@ Just select the one you want, and soon a zip file will be created in an `addons`
 From here, you can install it like a regular add-on.
 
 ## Future
+### v2.2
 * A "copy" mode, where just the functionality to build the node group is just copied to the clipbaord
+* Choose the location where to save the add-on
+
+### v2.3
 * Expansion to Compositing nodes
 * Add all referenced assets to the Asset Library for use outside of the original blend file
+
+### Later
 * Auto-set handle movies and image sequences
 * Automatically format code to be PEP8 compliant
 * Automatically detect the minimum version of Blender needed to run the add-on
 
 ## Potential Issues
-* As of version 2.0.1, the add-on will not set default values for
+* As of version 2.1, the add-on will not set default values for
     * Scripts
     * IES files
     * Filepaths
     * UV maps
+* This add-on doesn't currently set default values in Geometry Nodes modifiers, just the node groups themselves
 * Currently when setting default values for the following, the add-on must be run in the same blend file as the node group was created in to set the default, otherwise it will just set it to `None`:
     * Materials
     * Objects
@@ -67,4 +72,4 @@ When submitting an issue, please include
 * A short description of what you were trying to accomplish, or steps to reproduce the issue.
 * Sample blend files are more than welcome!
 
-Suggestions for how to improve the add-on are more than welcome!
+Got suggestions? Create an issue, happy to hear what features people want.

--- a/geo_nodes.py
+++ b/geo_nodes.py
@@ -4,96 +4,113 @@ import os
 from .utils import *
 
 #node tree input sockets that have default properties
-default_sockets = {'NodeSocketBool', 
-                   'NodeSocketColor',
-                   'NodeSocketFloat',
-                   'NodeSocketInt',
-                   'NodeSocketVector'}
+default_sockets = {'VALUE', 'INT', 'BOOLEAN', 'VECTOR', 'RGBA'}
 
 geo_node_settings = {
-    #attribute
+    # Attribute nodes
     "GeometryNodeAttributeStatistic" : ["data_type", "domain"],
-    "GeometryNodeCaptureAttribute" : ["data_type", "domain"],
     "GeometryNodeAttributeDomainSize" : ["component"],
+
+    "GeometryNodeBlurAttribute" : ["data_type"],
+    "GeometryNodeCaptureAttribute" : ["data_type", "domain"],
     "GeometryNodeStoreNamedAttribute" : ["data_type", "domain"],
     "GeometryNodeAttributeTransfer" : ["data_type", "mapping"],
 
-    #color
-    "ShaderNodeMixRGB"          : ["blend_type", "use_clamp"],
-    "FunctionNodeCombineColor"  : ["mode"],
-    "FunctionNodeSeparateColor" : ["mode"],
+    # Input Nodes
+    # Input > Constant
+    "FunctionNodeInputBool" : ["boolean"],
+    "FunctionNodeInputColor" : ["color"],
+    "FunctionNodeInputInt" : ["integer"],
+    "GeometryNodeInputMaterial" : ["material"],
+    "FunctionNodeInputString" : ["string"],
+    "FunctionNodeInputVector" : ["vector"],
 
-    #curve
-    "GeometryNodeCurveToPoints" : ["mode"],
-    "GeometryNodeFillCurve" : ["mode"], 
-    "GeometryNodeFilletCurve" : ["mode"],
-    "GeometryNodeResampleCurve" : ["mode"],
-    "GeometryNodeSampleCurve" : ["data_type", "mode", "use_all_curves"],
-    "GeometryNodeTrimCurve" : ["mode"],
-    "GeometryNodeSetCurveNormal" : ["mode"],
+    # Input > Scene
+    "GeometryNodeCollectionInfo" : ["transform_space"],
+    "GeometryNodeObjectInfo" : ["transform_space"],
+
+    # Output Nodes
+    "GeometryNodeViewer" : ["domain"],
+
+    # Geometry Nodes
+    # Geometry > Read
+    "GeometryNodeInputNamedAttribute" : ["data_type"],
+
+    # Geometry > Sample
+    "GeometryNodeProximity" : ["target_element"],
+    "GeometryNodeRaycast" : ["data_type", "mapping"],
+    "GeometryNodeSampleIndex" : ["data_type", "domain", "clamp"],
+    "GeometryNodeSampleNearest" : ["domain"],
+
+    # Geometry > Operations
+    "GeometryNodeDeleteGeometry" : ["domain", "mode"],
+    "GeometryNodeDuplicateElements" : ["domain"],
+    "GeometryNodeMergeByDistance" : ["mode"],
+    "GeometryNodeSeparateGeometry" : ["domain"],
+
+
+    # Curve
+    # Curve > Read
     "GeometryNodeCurveHandleTypeSelection" : ["mode", "handle_type"],
+
+    # Curve > Sample
+    "GeometryNodeSampleCurve" : ["data_type", "mode", "use_all_curves"],
+
+    # Curve > Write
+    "GeometryNodeSetCurveNormal" : ["mode"],
     "GeometryNodeSetCurveHandlePositions" : ["mode"],
     "GeometryNodeCurveSetHandles" : ["mode", "handle_type"],
     "GeometryNodeCurveSplineType" : ["spline_type"],
 
-    #curve primitives
+    # Curve > Operations
+    "GeometryNodeCurveToPoints" : ["mode"],
+    "GeometryNodeFillCurve" : ["mode"], 
+    "GeometryNodeFilletCurve" : ["mode"],
+    "GeometryNodeResampleCurve" : ["mode"],
+    "GeometryNodeTrimCurve" : ["mode"],
+
+    # Curve > Primitives
     "GeometryNodeCurveArc" : ["mode"],
     "GeometryNodeCurvePrimitiveBezierSegment" : ["mode"],
     "GeometryNodeCurvePrimitiveCircle" : ["mode"],
     "GeometryNodeCurvePrimitiveLine" : ["mode"],
     "GeometryNodeCurvePrimitiveQuadrilateral" : ["mode"],
 
-    #geometry
-    "GeometryNodeDeleteGeometry" : ["domain", "mode"],
-    "GeometryNodeDuplicateElements" : ["domain"],
-    "GeometryNodeProximity" : ["target_element"],
-    "GeometryNodeMergeByDistance" : ["mode"],
-    "GeometryNodeRaycast" : ["data_type", "mapping"],
-    "GeometryNodeSampleIndex" : ["data_type", "domain", "clamp"],
-    "GeometryNodeSampleNearest" : ["domain"],
-    "GeometryNodeSeparateGeometry" : ["domain"],
 
-    #input
-    "FunctionNodeInputBool" : ["boolean"],
-    "GeometryNodeCollectionInfo" : ["transform_space"],
-    "FunctionNodeInputColor" : ["color"],
-    "FunctionNodeInputInt" : ["integer"],
-    "GeometryNodeInputMaterial" : ["material"],
-    "GeometryNodeObjectInfo" : ["transform_space"],
-    "FunctionNodeInputString" : ["string"],
-    "FunctionNodeInputVector" : ["vector"],
-    "GeometryNodeInputNamedAttribute" : ["data_type"],
+    # Mesh Nodes
+    # Mesh > Sample
+    "GeometryNodeSampleNearestSurface" : ["data_type"],
+    "GeometryNodeSampleUVSurface" : ["data_type"],
 
-    #mesh
+    # Mesh > Operations
     "GeometryNodeExtrudeMesh" : ["mode"],
     "GeometryNodeMeshBoolean" : ["operation"],
     "GeometryNodeMeshToPoints" : ["mode"],
     "GeometryNodeMeshToVolume" : ["resolution_mode"],
-    "GeometryNodeSampleNearestSurface" : ["data_type"],
-    "GeometryNodeSampleUVSurface" : ["data_type"],
+    "GeometryNodeScaleElements" : ["domain", "scale_mode"],
     "GeometryNodeSubdivisionSurface" : ["uv_smooth", "boundary_smooth"],
     "GeometryNodeTriangulate" : ["quad_method", "ngon_method"],
-    "GeometryNodeScaleElements" : ["domain", "scale_mode"],
 
-    #mesh primitives
+    # Mesh > Primitives
     "GeometryNodeMeshCone" : ["fill_type"],
     "GeometryNodeMeshCylinder" : ["fill_type"],
     "GeometryNodeMeshCircle" : ["fill_type"],
     "GeometryNodeMeshLine" : ["mode"],
 
-    #output
-    "GeometryNodeViewer" : ["domain"],
-    
-    #point
+    # Mesh > UV
+    "GeometryNodeUVUnwrap" : ["method"],
+
+
+    # Point Nodes
     "GeometryNodeDistributePointsInVolume" : ["mode"],
     "GeometryNodeDistributePointsOnFaces" : ["distribute_method"],
     "GeometryNodePointsToVolume" : ["resolution_mode"],
 
-    #text
-    "GeometryNodeStringToCurves" : ["overflow", "align_x", "align_y", 
-                                    "pivot_mode"],
-    
-    #texture
+    # Volume Nodes
+    "GeometryNodeVolumeToMesh" : ["resolution_mode"],
+
+
+    # Texture Nodes
     "ShaderNodeTexBrick" : ["offset", "offset_frequency", "squash", 
                             "squash_frequency"],
     "ShaderNodeTexGradient" : ["gradient_type"],
@@ -104,35 +121,50 @@ geo_node_settings = {
     "ShaderNodeTexWave" : ["wave_type", "bands_direction", "wave_profile"],
     "ShaderNodeTexWhiteNoise" : ["noise_dimensions"],
 
-    #utilities
-    "GeometryNodeAccumulateField" : ["data_type", "domain"],
-    "FunctionNodeAlignEulerToVector" : ["axis", "pivot_axis"],
-    "FunctionNodeBooleanMath" : ["operation"],
-    "ShaderNodeClamp" : ["clamp_type"],
-    "FunctionNodeCompare" : ["data_type", "operation", "mode"],
-    "GeometryNodeFieldAtIndex" : ["data_type", "domain"],
-    "FunctionNodeFloatToInt" : ["rounding_mode"],
-    "GeometryNodeFieldOnDomain" : ["data_type", "domain" ],
-    "ShaderNodeMapRange" : ["data_type", "interpolation_type", "clamp"], 
-    "ShaderNodeMath" : ["operation", "use_clamp"],
-    "FunctionNodeRandomValue" : ["data_type"],
-    "FunctionNodeRotateEuler" : ["type", "space"],
-    "GeometryNodeSwitch" : ["input_type"],
 
-    #uv
-    "GeometryNodeUVUnwrap" : ["method"],
+    # Utilities
+    # Utilities > Color
+    "FunctionNodeCombineColor" : ["mode"],
+    "ShaderNodeMixRGB" : ["blend_type", "use_clamp"], #legacy
+    "FunctionNodeSeparateColor" : ["mode"],
+    
+    # Utilities > Text
+    "GeometryNodeStringToCurves" : ["overflow", "align_x", "align_y", 
+                                    "pivot_mode"],
 
-    #vector
+    # Utilities > Vector
     "ShaderNodeVectorMath" : ["operation"],
     "ShaderNodeVectorRotate" : ["rotation_type", "invert"],
 
-    #volume
-    "GeometryNodeVolumeToMesh" : ["resolution_mode"]
+    # Utilities > Field
+    "GeometryNodeAccumulateField" : ["data_type", "domain"],
+    "GeometryNodeFieldAtIndex" : ["data_type", "domain"],
+    "GeometryNodeFieldOnDomain" : ["data_type", "domain" ],
+
+    # Utilities > Math
+    "FunctionNodeBooleanMath" : ["operation"],
+    "ShaderNodeClamp" : ["clamp_type"],
+    "FunctionNodeCompare" : ["data_type", "operation", "mode"],
+    "FunctionNodeFloatToInt" : ["rounding_mode"],
+    "ShaderNodeMapRange" : ["data_type", "interpolation_type", "clamp"], 
+    "ShaderNodeMath" : ["operation", "use_clamp"],
+
+    # Utilities > Rotate
+    "FunctionNodeAlignEulerToVector" : ["axis", "pivot_axis"],
+    "FunctionNodeRotateEuler" : ["type", "space"],
+
+    # Utilities > General
+    "ShaderNodeMix" : ["data_type", "blend_type", "clamp_result", 
+                       "clamp_factor", "factor_mode"],
+    "FunctionNodeRandomValue" : ["data_type"],
+    "GeometryNodeSwitch" : ["input_type"]
 }
 
 curve_nodes = {'ShaderNodeFloatCurve', 
                'ShaderNodeVectorCurve', 
                'ShaderNodeRGBCurve'}
+
+image_nodes = {'GeometryNodeInputImage'}
 
 class GeoNodesToPython(bpy.types.Operator):
     bl_idname = "node.geo_nodes_to_python"
@@ -215,14 +247,11 @@ class GeoNodesToPython(bpy.types.Operator):
                                         f"(\"{input.bl_idname}\", "
                                         f"\"{input.name}\")\n"))
                             socket = node_tree.inputs[i]
-                            if input.bl_idname in default_sockets:  
-                                if input.bl_idname == 'NodeSocketColor':
-                                    col = socket.default_value
-                                    r, g, b, a = col[0], col[1], col[2], col[3]
-                                    dv = f"({r}, {g}, {b}, {a})"
-                                elif input.bl_idname == 'NodeSocketVector':
-                                    vec = socket.default_value
-                                    dv = f"({vec[0]}, {vec[1]}, {vec[2]})"
+                            if input.type in default_sockets:  
+                                if input.type == 'RGBA':
+                                    dv = vec4_to_py_str(socket.default_value)
+                                elif input.type == 'VECTOR':
+                                    dv = vec3_to_py_str(socket.default_value)
                                 else:
                                     dv = socket.default_value
                                 
@@ -263,6 +292,14 @@ class GeoNodesToPython(bpy.types.Operator):
                                             f".inputs[{i}]"
                                             f".hide_value = "
                                             f"{socket.hide_value}\n"))
+
+                            #hide in modifier
+                            if hasattr(socket, "hide_in_modifier"):
+                                if socket.hide_in_modifier is True:
+                                    file.write((f"{inner}{node_tree_var}"
+                                                f".inputs[{i}]"
+                                                f".hide_in_modifier = "
+                                                f"{socket.hide_in_modifier}\n"))
                             file.write("\n")
                     file.write("\n")
                     inputs_set = True
@@ -276,6 +313,31 @@ class GeoNodesToPython(bpy.types.Operator):
                                         f"\"{output.name}\")\n"))
                             
                             socket = node_tree.outputs[i]
+                            if output.type in default_sockets:  
+                                if output.type == 'RGBA':
+                                    dv = vec4_to_py_str(socket.default_value)
+                                elif output.type == 'VECTOR':
+                                    dv = vec3_to_py_str(socket.default_value)
+                                else:
+                                    dv = socket.default_value
+                                
+                                #default value
+                                file.write((f"{inner}{node_tree_var}"
+                                            f".outputs[{i}]"
+                                            f".default_value = {dv}\n"))
+
+                                #min value
+                                if hasattr(socket, "min_value"):
+                                    file.write((f"{inner}{node_tree_var}"
+                                                f".outputs[{i}]"
+                                                f".min_value = "
+                                                f"{socket.min_value}\n"))
+                                #max value
+                                if hasattr(socket, "max_value"):
+                                    file.write((f"{inner}{node_tree_var}"
+                                                f".outputs[{i}]"
+                                                f".max_value = "
+                                                f"{socket.max_value}\n"))
                             #description
                             if socket.description != "":
                                 file.write((f"{inner}{node_tree_var}"
@@ -302,7 +364,8 @@ class GeoNodesToPython(bpy.types.Operator):
                                 file.write((f"{inner}{node_tree_var}"
                                             f".outputs[{i}]"
                                             f".attribute_domain = "
-                                            f"\'{socket.attribute_domain}\'\n"))             
+                                            f"\'{socket.attribute_domain}\'\n"))
+
                     file.write("\n")
                     outputs_set = True
 
@@ -322,6 +385,11 @@ class GeoNodesToPython(bpy.types.Operator):
                     color_ramp_settings(node, file, inner, node_var)
                 elif node.bl_idname in curve_nodes:
                     curve_node_settings(node, file, inner, node_var)
+                elif node.bl_idname in image_nodes:
+                    img = node.image
+                    if img.source in {'FILE', 'GENERATED', 'TILED'}:
+                        save_image(img, addon_dir)
+                        load_image(img, file, inner, f"{node_var}.image")
                 
                 set_input_defaults(node, file, inner, node_var, addon_dir)
                 set_output_defaults(node, file, inner, node_var)

--- a/utils.py
+++ b/utils.py
@@ -492,9 +492,12 @@ def set_parents(node_tree, file: TextIO, inner: str, node_vars: dict):
     inner (str): indentation string
     node_vars (dict): dictionary for (node, variable) name pairs
     """
-    file.write(f"{inner}#Set parents\n")
+    parent_comment = False
     for node in node_tree.nodes:
         if node is not None and node.parent is not None:
+            if not parent_comment:
+                file.write(f"{inner}#Set parents\n")
+                parent_comment = True
             node_var = node_vars[node]
             parent_var = node_vars[node.parent]
             file.write(f"{inner}{node_var}.parent = {parent_var}\n")
@@ -529,7 +532,7 @@ def set_dimensions(node_tree, file: TextIO, inner: str, node_vars: dict):
     node_vars (dict): dictionary for (node, variable) name pairs
     """
 
-    file.write(f"{inner}#sSet dimensions\n")
+    file.write(f"{inner}#Set dimensions\n")
     for node in node_tree.nodes:
         node_var = node_vars[node]
         file.write((f"{inner}{node_var}.width, {node_var}.height "


### PR DESCRIPTION
**Features**
* Support for new nodes from Blender versions 3.5 and 3.6
* Simulation nodes!
* Node Group outputs now set default values
* Add Hide In Modifier attributes
* Supports node socket subtypes

**Fixes**
* No longer comments `#Set Parents` if there aren't any to be set

**Refactor**
* Reorganized `geo_node_settings` dictionary to follow new organization from Blender 3.5
* Node group inputs now set default values using string functions from `utils.py`

**Documentation**
* Updated versions
* Added geometry nodes modifier won't set default values to potential issues
* Updated roadmap