### PR TITLE
Addon packaging fixes

### DIFF
--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -186,7 +186,8 @@ class NTPCompositorOperator(NTP_Operator):
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
-            self._setup_addon_directories(context, comp_var)
+            if not self._setup_addon_directories(context, comp_var):
+                return {'CANCELLED'}
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
 

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -223,7 +223,8 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
-            self._setup_addon_directories(context, nt_var)
+            if not self._setup_addon_directories(context, nt_var):
+                return {'CANCELLED'}
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
             

--- a/material/operator.py
+++ b/material/operator.py
@@ -137,7 +137,8 @@ class NTPMaterialOperator(NTP_Operator):
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
-            self._setup_addon_directories(context, mat_var)
+            if not self._setup_addon_directories(context, mat_var):
+                return {'CANCELLED'}
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
 
@@ -171,7 +172,7 @@ class NTPMaterialOperator(NTP_Operator):
         self._file.close()
         
         if self.mode == 'ADDON':
-            self._zip_addon(self._zip_dir)
+            self._zip_addon()
 
         self._report_finished("material")
 

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -109,23 +109,32 @@ class NTP_Operator(Operator):
             indent = self._inner
         self._file.write(f"{indent}{string}\n")
 
-    def _setup_addon_directories(self, context: Context, nt_var: str) -> None:
+    def _setup_addon_directories(self, context: Context, nt_var: str) -> bool:
         """
         Finds/creates directories to save add-on to
+
+        Parameters:
+        context (Context): the current scene context
+        nt_var (str): variable name of the ndoe tree
+
+        Returns:
+        (bool): success of addon directory setup
         """
         # find base directory to save new addon
         self._dir = bpy.path.abspath(context.scene.ntp_options.dir_path)
         if not self._dir or self._dir == "":
             self.report({'ERROR'},
-                        ("NodeToPython: Save your blend file before using "
-                         "NodeToPython!"))  # TODO: Still valid??
-            return {'CANCELLED'}  # TODO
+                        ("NodeToPython: No save location found. Please select "
+                         "one in the NodeToPython Options panel"))
+            return False
 
         self._zip_dir = os.path.join(self._dir, nt_var)
         self._addon_dir = os.path.join(self._zip_dir, nt_var)
 
         if not os.path.exists(self._addon_dir):
             os.makedirs(self._addon_dir)
+        
+        return True
 
     def _create_header(self, name: str) -> None:
         """


### PR DESCRIPTION
* Removed bad parameter from material addon zip function call (#87)
* NTP now properly aborts when it can't find a save location
* More appropriate error message for not finding a save location