### PR TITLE
Options expansion

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -7,9 +7,6 @@ tagline = "Turn node groups into Python code"
 maintainer = "Brendan Parmer <brendanparmer+nodetopython@gmail.com>"
 type = "add-on"
 
-# In add-on mode, NodeToPython will create and write to files at a specified directory
-permissions = ["files"]
-
 website = "https://github.com/BrendanParmer/NodeToPython"
 
 tags = ["Development", "Compositing", "Geometry Nodes", "Material", "Node"]
@@ -20,3 +17,6 @@ blender_version_max = "4.3.0"
 license = [
     "SPDX:MIT",
 ]
+
+[permissions]
+files = "In add-on mode, NodeToPython will create and write to files in a specified directory"

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,34 @@
+schema_version = "1.0.0"
+
+# Example of manifest file for a Blender extension
+# Change the values according to your extension
+id = "node_to_python"
+version = "3.2.0"
+name = "Node To Python"
+tagline = "Turn node groups into Python code"
+maintainer = "Brendan Parmer <brendanparmer+nodetopython@gmail.com>"
+# Supported types: "add-on", "theme"
+type = "add-on"
+
+# Optional: add-ons can list which resources they will require:
+# * "files" (for access of any filesystem operations)
+# * "network" (for internet access)
+# * "clipboard" (to read and/or write the system clipboard)
+# * "camera" (to capture photos and videos)
+# * "microphone" (to capture audio)
+# permissions = ["files"]
+
+# Optional link to documentation, support, source files, etc
+# website = "https://github.com/BrendanParmer/NodeToPython"
+
+# Optional list defined by Blender and server, see:
+# https://docs.blender.org/manual/en/dev/extensions/tags.html
+tags = ["Development", "Compositing", "Geometry Nodes", "Material"]
+
+blender_version_min = "4.2.0"
+# Optional: maximum supported Blender version
+# blender_version_max = "5.1.0"
+
+license = [
+    "SPDX:MIT",
+]

--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -203,7 +203,7 @@ class NTPCompositorOperator(NTP_Operator):
         #set up names to use in generated addon
         comp_var = clean_string(self.compositor_name)
         
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
@@ -223,9 +223,9 @@ class NTPCompositorOperator(NTP_Operator):
                 self._file.write("import bpy, mathutils\n\n")
 
         if self.is_scene:
-            if self.mode == 'ADDON':
+            if self._mode == 'ADDON':
                 self._create_scene("\t\t")
-            elif self.mode == 'SCRIPT':
+            elif self._mode == 'SCRIPT':
                 self._create_scene("")
 
         node_trees_to_process = self._topological_sort(self._base_node_tree)
@@ -233,7 +233,7 @@ class NTPCompositorOperator(NTP_Operator):
         for node_tree in node_trees_to_process:  
             self._process_node_tree(node_tree)
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._write("return {'FINISHED'}\n", self._outer)
 
             self._create_menu_func()
@@ -245,7 +245,7 @@ class NTPCompositorOperator(NTP_Operator):
 
         self._file.close()
         
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._zip_addon()
         
         self._report_finished("compositor nodes")

--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -185,7 +185,8 @@ class NTPCompositorOperator(NTP_Operator):
         self._write(f"{nt_var} = {nt_var}_node_group()\n", self._outer)
     
     def execute(self, context):
-        self._setup_options(context.scene.ntp_options)
+        if not self._setup_options(context.scene.ntp_options):
+            return {'CANCELLED'}
 
         #find node group to replicate
         if self.is_scene:

--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -20,14 +20,6 @@ class NTPCompositorOperator(NTP_Operator):
     bl_idname = "node.ntp_compositor"
     bl_label =  "Compositor to Python"
     bl_options = {'REGISTER', 'UNDO'}
-
-    mode : bpy.props.EnumProperty(
-        name = "Mode",
-        items = [
-            ('SCRIPT', "Script", "Copy just the node group to the Blender clipboard"),
-            ('ADDON', "Addon", "Create a full addon")
-        ]
-    )
     
     compositor_name: bpy.props.StringProperty(name="Node Group")
     is_scene : bpy.props.BoolProperty(name="Is Scene", description="Blender stores compositing node trees differently for scenes and in groups")

--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -187,6 +187,8 @@ class NTPCompositorOperator(NTP_Operator):
         self._write(f"{nt_var} = {nt_var}_node_group()\n", self._outer)
     
     def execute(self, context):
+        self._setup_options(context.scene.ntp_options)
+
         #find node group to replicate
         if self.is_scene:
             self._base_node_tree = bpy.data.scenes[self.compositor_name].node_tree
@@ -219,7 +221,7 @@ class NTPCompositorOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
-            if context.scene.ntp_options.include_imports:
+            if self._include_imports:
                 self._file.write("import bpy, mathutils\n\n")
 
         if self.is_scene:

--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -219,6 +219,8 @@ class NTPCompositorOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
+            if context.scene.ntp_options.include_imports:
+                self._file.write("import bpy, mathutils\n\n")
 
         if self.is_scene:
             if self.mode == 'ADDON':

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -20,7 +20,7 @@ class NTPGeoNodesOperator(NTP_Operator):
     bl_idname = "node.ntp_geo_nodes"
     bl_label = "Geo Nodes to Python"
     bl_options = {'REGISTER', 'UNDO'}
-    
+
     geo_nodes_group_name: bpy.props.StringProperty(name="Node Group")
 
     def __init__(self):
@@ -179,7 +179,7 @@ class NTPGeoNodesOperator(NTP_Operator):
         #set up names to use in generated addon
         nt_var = clean_string(nt.name)
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
@@ -203,7 +203,7 @@ class NTPGeoNodesOperator(NTP_Operator):
         for node_tree in node_trees_to_process:  
             self._process_node_tree(node_tree)
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._apply_modifier(nt, nt_var)
             self._write("return {'FINISHED'}\n", self._outer)
             self._create_menu_func()
@@ -214,7 +214,7 @@ class NTPGeoNodesOperator(NTP_Operator):
             context.window_manager.clipboard = self._file.getvalue()
         self._file.close()
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._zip_addon()
 
         self._report_finished("geometry node group")

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -200,6 +200,9 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
+            if context.scene.ntp_options.include_imports:
+                self._file.write("import bpy, mathutils\n\n")
+
 
         node_trees_to_process = self._topological_sort(nt)
 

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -21,14 +21,6 @@ class NTPGeoNodesOperator(NTP_Operator):
     bl_label = "Geo Nodes to Python"
     bl_options = {'REGISTER', 'UNDO'}
     
-    mode: bpy.props.EnumProperty(
-        name = "Mode",
-        items = [
-            ('SCRIPT', "Script", "Copy just the node group to the Blender clipboard"),
-            ('ADDON',  "Addon", "Create a full addon")
-        ]
-    )
-
     geo_nodes_group_name: bpy.props.StringProperty(name="Node Group")
 
     def __init__(self):

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -179,6 +179,8 @@ class NTPGeoNodesOperator(NTP_Operator):
 
 
     def execute(self, context):
+        self._setup_options(context.scene.ntp_options)
+
         #find node group to replicate
         nt = bpy.data.node_groups[self.geo_nodes_group_name]
 
@@ -200,7 +202,7 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
-            if context.scene.ntp_options.include_imports:
+            if self._include_imports:
                 self._file.write("import bpy, mathutils\n\n")
 
 

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -171,7 +171,8 @@ class NTPGeoNodesOperator(NTP_Operator):
 
 
     def execute(self, context):
-        self._setup_options(context.scene.ntp_options)
+        if not self._setup_options(context.scene.ntp_options):
+            return {'CANCELLED'}
 
         #find node group to replicate
         nt = bpy.data.node_groups[self.geo_nodes_group_name]

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -117,12 +117,14 @@ class NTP_Operator(Operator):
         self._file.write(f"{indent}{string}\n")
 
     def _setup_options(self, options: NTPOptions) -> None:
-        self.mode = options.mode
+        self._mode = options.mode
         self._include_imports = options.include_imports
         self._include_group_socket_values = options.include_group_socket_values
         self._should_set_dimensions = options.set_dimensions
         if bpy.app.version >= (3, 4, 0):
             self._set_unavailable_defaults = options.set_unavailable_defaults
+        self._author_name = options.author_name
+        self._version = options.version
 
     def _setup_addon_directories(self, context: Context, nt_var: str) -> bool:
         """
@@ -161,9 +163,9 @@ class NTP_Operator(Operator):
         """
 
         self._write("bl_info = {", "")
-        self._write(f"\t\"name\" : \"{name}\",", "")
-        self._write("\t\"author\" : \"Node To Python\",", "")
-        self._write("\t\"version\" : (1, 0, 0),", "")
+        self._write(f"\t\"name\" : {str_to_py_str(name)},", "")
+        self._write(f"\t\"author\" : {str_to_py_str(self._author_name)},", "")
+        self._write(f"\t\"version\" : {vec3_to_py_str(self._version)},", "")
         self._write(f"\t\"blender\" : {bpy.app.version},", "")
         self._write("\t\"location\" : \"Object\",", "")  # TODO
         self._write("\t\"category\" : \"Node\"", "")
@@ -1370,7 +1372,7 @@ class NTP_Operator(Operator):
         object (str): the copied node tree or encapsulating structure
             (geometry node modifier, material, scene, etc.)
         """
-        if self.mode == 'SCRIPT':
+        if self._mode == 'SCRIPT':
             location = "clipboard"
         else:
             location = self._dir

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -113,7 +113,7 @@ class NTP_Operator(Operator):
             indent = self._inner
         self._file.write(f"{indent}{string}\n")
 
-    def _setup_options(self, options: NTPOptions) -> None:
+    def _setup_options(self, options: NTPOptions) -> bool:
         # General
         self._mode = options.mode
         self._include_group_socket_values = options.include_group_socket_values
@@ -134,7 +134,12 @@ class NTP_Operator(Operator):
             self._location = options.location
             self._category = options.category
             self._custom_category = options.custom_category
-            self._menu_id = options.menu_id
+            if options.menu_id in dir(bpy.types):
+                self._menu_id = options.menu_id
+            else:
+                self.report({'ERROR'}, f"{options.menu_id} is not a valid menu")
+                return False
+            return True
 
     def _setup_addon_directories(self, context: Context, nt_var: str) -> bool:
         """

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -47,14 +47,6 @@ class NTP_Operator(Operator):
     bl_idname = ""
     bl_label = ""
 
-    mode: bpy.props.EnumProperty(
-        name="Mode",
-        items=[
-            ('SCRIPT', "Script", "Copy just the node group to the Blender clipboard"),
-            ('ADDON', "Addon", "Create a full addon")
-        ]
-    )
-
     # node tree input sockets that have default properties
     if bpy.app.version < (4, 0, 0):
         default_sockets_v3 = {'VALUE', 'INT', 'BOOLEAN', 'VECTOR', 'RGBA'}
@@ -125,6 +117,7 @@ class NTP_Operator(Operator):
         self._file.write(f"{indent}{string}\n")
 
     def _setup_options(self, options: NTPOptions) -> None:
+        self.mode = options.mode
         self._include_imports = options.include_imports
         self._include_group_socket_values = options.include_group_socket_values
         self._should_set_dimensions = options.set_dimensions
@@ -1386,9 +1379,3 @@ class NTP_Operator(Operator):
     # ABSTRACT
     def execute(self):
         return {'FINISHED'}
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self)
-
-    def draw(self, context):
-        self.layout.prop(self, "mode")

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -14,6 +14,7 @@ from typing import TextIO
 import shutil
 
 from .ntp_node_tree import NTP_NodeTree
+from .options import NTPOptions
 from .utils import *
 
 INDEX = "i"
@@ -106,10 +107,27 @@ class NTP_Operator(Operator):
         for name in RESERVED_NAMES:
             self._used_vars[name] = 0
 
+        # Generate socket default, min, and max values
+        self._include_socket_values = True
+
+        # Set dimensions of generated nodes
+        self._should_set_dimensions = True
+
+        if bpy.app.version >= (3, 4, 0):
+            # Set default values for hidden sockets
+            self._set_hidden_defaults = False
+
     def _write(self, string: str, indent: str = None):
         if indent is None:
             indent = self._inner
         self._file.write(f"{indent}{string}\n")
+
+    def _setup_options(self, options: NTPOptions) -> None:
+        self._include_imports = options.include_imports
+        self._include_socket_values = options.include_socket_values
+        self._should_set_dimensions = options.set_dimensions
+        if bpy.app.version >= (3, 4, 0):
+            self._set_hidden_defaults = options.set_hidden_defaults
 
     def _setup_addon_directories(self, context: Context, nt_var: str) -> bool:
         """
@@ -381,6 +399,9 @@ class NTP_Operator(Operator):
                 with the input/output
             socket_var (str): variable name for the socket
             """
+            if not self._include_socket_values:
+                return
+
             if socket_interface.type not in self.default_sockets_v3:
                 return
 
@@ -477,6 +498,8 @@ class NTP_Operator(Operator):
                 with the input/output
             socket_var (str): variable name for the socket
             """
+            if not self._include_socket_values:
+                return
             if type(socket_interface) in self.nondefault_sockets_v4:
                 return
 
@@ -707,6 +730,10 @@ class NTP_Operator(Operator):
 
         for i, input in enumerate(node.inputs):
             if input.bl_idname not in DONT_SET_DEFAULTS and not input.is_linked:
+                if bpy.app.version >= (3, 4, 0):
+                    if (not self._set_hidden_defaults) and input.is_unavailable:
+                        continue
+                    
                 # TODO: this could be cleaner
                 socket_var = f"{node_var}.inputs[{i}]"
 
@@ -1187,6 +1214,9 @@ class NTP_Operator(Operator):
         Parameters:
         node_tree (NodeTree): node tree we're obtaining nodes from
         """
+        if not self._should_set_dimensions:
+            return
+
         self._write(f"#Set dimensions")
         for node in node_tree.nodes:
             node_var = self._node_vars[node]

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -1048,13 +1048,19 @@ class NTP_Operator(Operator):
         if img is None:
             return
 
+        img_str = img_to_py_str(img)
+
+        if not img.has_data:
+            self.report({'WARNING'}, f"{img_str} has no data")
+            return
+
         # create image dir if one doesn't exist
         img_dir = os.path.join(self._addon_dir, IMAGE_DIR_NAME)
         if not os.path.exists(img_dir):
             os.mkdir(img_dir)
 
         # save the image
-        img_str = img_to_py_str(img)
+        
         img_path = f"{img_dir}/{img_str}"
         if not os.path.exists(img_path):
             img.save_render(img_path)

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -108,14 +108,14 @@ class NTP_Operator(Operator):
             self._used_vars[name] = 0
 
         # Generate socket default, min, and max values
-        self._include_socket_values = True
+        self._include_group_socket_values = True
 
         # Set dimensions of generated nodes
         self._should_set_dimensions = True
 
         if bpy.app.version >= (3, 4, 0):
             # Set default values for hidden sockets
-            self._set_hidden_defaults = False
+            self._set_unavailable_defaults = False
 
     def _write(self, string: str, indent: str = None):
         if indent is None:
@@ -124,10 +124,10 @@ class NTP_Operator(Operator):
 
     def _setup_options(self, options: NTPOptions) -> None:
         self._include_imports = options.include_imports
-        self._include_socket_values = options.include_socket_values
+        self._include_group_socket_values = options.include_group_socket_values
         self._should_set_dimensions = options.set_dimensions
         if bpy.app.version >= (3, 4, 0):
-            self._set_hidden_defaults = options.set_hidden_defaults
+            self._set_unavailable_defaults = options.set_unavailable_defaults
 
     def _setup_addon_directories(self, context: Context, nt_var: str) -> bool:
         """
@@ -399,7 +399,7 @@ class NTP_Operator(Operator):
                 with the input/output
             socket_var (str): variable name for the socket
             """
-            if not self._include_socket_values:
+            if not self._include_group_socket_values:
                 return
 
             if socket_interface.type not in self.default_sockets_v3:
@@ -498,7 +498,7 @@ class NTP_Operator(Operator):
                 with the input/output
             socket_var (str): variable name for the socket
             """
-            if not self._include_socket_values:
+            if not self._include_group_socket_values:
                 return
             if type(socket_interface) in self.nondefault_sockets_v4:
                 return
@@ -731,7 +731,7 @@ class NTP_Operator(Operator):
         for i, input in enumerate(node.inputs):
             if input.bl_idname not in DONT_SET_DEFAULTS and not input.is_linked:
                 if bpy.app.version >= (3, 4, 0):
-                    if (not self._set_hidden_defaults) and input.is_unavailable:
+                    if (not self._set_unavailable_defaults) and input.is_unavailable:
                         continue
                     
                 # TODO: this could be cleaner

--- a/options.py
+++ b/options.py
@@ -55,6 +55,6 @@ class NTPOptionsPanel(bpy.types.Panel):
             "set_dimensions"
         ]
         if bpy.app.version >= (3, 4, 0):
-            option_list.append("set_hidden_defaults")
+            option_list.append("set_unavailable_defaults")
         for option in option_list:
             layout.prop(ntp_options, option)

--- a/options.py
+++ b/options.py
@@ -10,6 +10,11 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Save location if generating an add-on",
         default = "//"
     )
+    include_imports : bpy.props.BoolProperty(
+        name = "Include imports",
+        description="Generate necessary import statements",
+        default = True
+    )
 
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
@@ -26,3 +31,4 @@ class NTPOptionsPanel(bpy.types.Panel):
         layout = self.layout
         layout.operator_context = 'INVOKE_DEFAULT'
         layout.prop(context.scene.ntp_options, "dir_path")
+        layout.prop(context.scene.ntp_options, "include_imports")

--- a/options.py
+++ b/options.py
@@ -42,6 +42,16 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Save location if generating an add-on",
         default = "//"
     )
+    name_override : bpy.props.StringProperty(
+        name = "Name Override",
+        description="Name used for the add-on's, default is node group name",
+        default = ""
+    )
+    description : bpy.props.StringProperty(
+        name = "Description",
+        description="Description used for the add-on",
+        default=""
+    )
     author_name : bpy.props.StringProperty(
         name = "Author",
         description = "Name used for the author/maintainer of the add-on",
@@ -52,7 +62,61 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Version of the add-on",
         default = (1, 0, 0)
     )
-
+    location: bpy.props.StringProperty(
+        name = "Location",
+        description="Location of the addon",
+        default="Node"
+    )
+    menu_id: bpy.props.StringProperty(
+        name = "Menu ID",
+        description = "Python ID of the menu you'd like to register the add-on "
+                      "to. You can find this by enabling Python tooltips "
+                      "(Preferences > Interface > Python tooltips) and "
+                      "hovering over the desired menu",
+        default="NODE_MT_add"
+    )
+    category: bpy.props.EnumProperty(
+        name = "Category",
+        items = [
+            ('Custom',          "Custom",           "Use an unofficial category"),
+            ('3D View',         "3D View",          ""),
+            ('Add Curve',       "Add Curve",        ""),
+            ('Add Mesh',        "Add Mesh",         ""),
+            ('Animation',       "Animation",        ""),
+            ('Bake',            "Bake",             ""),
+            ('Compositing',     "Compositing",      ""),
+            ('Development',     "Development",      ""),
+            ('Game Engine',     "Game Engine",      ""),
+            ('Geometry Nodes',  "Geometry Nodes",   ""),
+            ("Grease Pencil",   "Grease Pencil",    ""),
+            ('Import-Export',   "Import-Export",    ""),
+            ('Lighting',        "Lighting",         ""),
+            ('Material',        "Material",         ""),
+            ('Mesh',            "Mesh",             ""),
+            ('Modeling',        "Modeling",         ""),
+            ('Node',            "Node",             ""),
+            ('Object',          "Object",           ""),
+            ('Paint',           "Paint",            ""),
+            ('Pipeline',        "Pipeline",         ""),
+            ('Physics',         "Physics",          ""),
+            ('Render',          "Render",           ""),
+            ('Rigging',         "Rigging",          ""),
+            ('Scene',           "Scene",            ""),
+            ('Sculpt',          "Sculpt",           ""),
+            ('Sequencer',       "Sequencer",        ""),
+            ('System',          "System",           ""),
+            ('Text Editor',     "Text Editor",      ""),
+            ('Tracking',        "Tracking",         ""),
+            ('UV',              "UV",               ""),
+            ('User Interface',  "User Interface",   ""),
+        ],
+        default = 'Node'
+    )
+    custom_category: bpy.props.StringProperty(
+        name="Custom Category",
+        description="Custom category",
+        default = ""
+    )
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
     bl_idname = "NODE_PT_ntp_options"
@@ -86,9 +150,14 @@ class NTPOptionsPanel(bpy.types.Panel):
             addon_options = [
                 "dir_path",
                 "author_name",
-                "version"
+                "version",
+                "location",
+                "menu_id",
+                "category"
             ]
             option_list += addon_options
+            if ntp_options.category == 'CUSTOM':
+                option_list.append("custom_category")
 
         for option in option_list:
             layout.prop(ntp_options, option)

--- a/options.py
+++ b/options.py
@@ -15,8 +15,8 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Generate necessary import statements",
         default = True
     )
-    include_socket_values : bpy.props.BoolProperty(
-        name = "Include socket values",
+    include_group_socket_values : bpy.props.BoolProperty(
+        name = "Include group socket values",
         description = "Generate group socket default, min, and max values",
         default = True
     )
@@ -26,9 +26,9 @@ class NTPOptions(bpy.types.PropertyGroup):
         default = True
     )
     if bpy.app.version >= (3, 4, 0):
-        set_hidden_defaults : bpy.props.BoolProperty(
-            name = "Set hidden defaults",
-            description = "Set default values for hidden sockets",
+        set_unavailable_defaults : bpy.props.BoolProperty(
+            name = "Set unavailable defaults",
+            description = "Set default values for unavailable sockets",
             default = False
         )
 
@@ -50,7 +50,8 @@ class NTPOptionsPanel(bpy.types.Panel):
 
         option_list = [
             "dir_path", 
-            "include_imports", "include_socket_values",
+            "include_imports", 
+            "include_group_socket_values",
             "set_dimensions"
         ]
         if bpy.app.version >= (3, 4, 0):

--- a/options.py
+++ b/options.py
@@ -42,6 +42,16 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Save location if generating an add-on",
         default = "//"
     )
+    author_name : bpy.props.StringProperty(
+        name = "Author",
+        description = "Name used for the author/maintainer of the add-on",
+        default = "Node To Python"
+    )
+    version: bpy.props.IntVectorProperty(
+        name = "Version",
+        description="Version of the add-on",
+        default = (1, 0, 0)
+    )
 
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
@@ -74,7 +84,9 @@ class NTPOptionsPanel(bpy.types.Panel):
             option_list += script_options
         elif ntp_options.mode == 'ADDON':
             addon_options = [
-                "dir_path"
+                "dir_path",
+                "author_name",
+                "version"
             ]
             option_list += addon_options
 

--- a/options.py
+++ b/options.py
@@ -4,16 +4,13 @@ class NTPOptions(bpy.types.PropertyGroup):
     """
     Property group used during conversion of node group to python
     """
-    dir_path : bpy.props.StringProperty(
-        name = "Save Location",
-        subtype='DIR_PATH',
-        description="Save location if generating an add-on",
-        default = "//"
-    )
-    include_imports : bpy.props.BoolProperty(
-        name = "Include imports",
-        description="Generate necessary import statements",
-        default = True
+    # General properties
+    mode: bpy.props.EnumProperty(
+        name = "Mode",
+        items = [
+            ('SCRIPT', "Script", "Copy just the node group to the Blender clipboard"),
+            ('ADDON', "Addon", "Create a full add-on")
+        ]
     )
     include_group_socket_values : bpy.props.BoolProperty(
         name = "Include group socket values",
@@ -32,6 +29,20 @@ class NTPOptions(bpy.types.PropertyGroup):
             default = False
         )
 
+    #Script properties
+    include_imports : bpy.props.BoolProperty(
+        name = "Include imports",
+        description="Generate necessary import statements",
+        default = True
+    )
+    # Addon properties
+    dir_path : bpy.props.StringProperty(
+        name = "Save Location",
+        subtype='DIR_PATH',
+        description="Save location if generating an add-on",
+        default = "//"
+    )
+
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
     bl_idname = "NODE_PT_ntp_options"
@@ -49,12 +60,23 @@ class NTPOptionsPanel(bpy.types.Panel):
         ntp_options = context.scene.ntp_options
 
         option_list = [
-            "dir_path", 
-            "include_imports", 
+            "mode",
             "include_group_socket_values",
             "set_dimensions"
         ]
         if bpy.app.version >= (3, 4, 0):
             option_list.append("set_unavailable_defaults")
+        
+        if ntp_options.mode == 'SCRIPT':
+            script_options = [
+                "include_imports"
+            ]
+            option_list += script_options
+        elif ntp_options.mode == 'ADDON':
+            addon_options = [
+                "dir_path"
+            ]
+            option_list += addon_options
+
         for option in option_list:
             layout.prop(ntp_options, option)

--- a/options.py
+++ b/options.py
@@ -15,6 +15,22 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Generate necessary import statements",
         default = True
     )
+    include_socket_values : bpy.props.BoolProperty(
+        name = "Include socket values",
+        description = "Generate group socket default, min, and max values",
+        default = True
+    )
+    set_dimensions : bpy.props.BoolProperty(
+        name = "Set dimensions",
+        description = "Set dimensions of generated nodes",
+        default = True
+    )
+    if bpy.app.version >= (3, 4, 0):
+        set_hidden_defaults : bpy.props.BoolProperty(
+            name = "Set hidden defaults",
+            description = "Set default values for hidden sockets",
+            default = False
+        )
 
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
@@ -30,5 +46,14 @@ class NTPOptionsPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator_context = 'INVOKE_DEFAULT'
-        layout.prop(context.scene.ntp_options, "dir_path")
-        layout.prop(context.scene.ntp_options, "include_imports")
+        ntp_options = context.scene.ntp_options
+
+        option_list = [
+            "dir_path", 
+            "include_imports", "include_socket_values",
+            "set_dimensions"
+        ]
+        if bpy.app.version >= (3, 4, 0):
+            option_list.append("set_hidden_defaults")
+        for option in option_list:
+            layout.prop(ntp_options, option)

--- a/shader/operator.py
+++ b/shader/operator.py
@@ -123,6 +123,8 @@ class NTPShaderOperator(NTP_Operator):
         
 
     def execute(self, context):
+        self._setup_options(context.scene.ntp_options)
+        
         #find node group to replicate
         self._base_node_tree = bpy.data.materials[self.material_name].node_tree
         if self._base_node_tree is None:
@@ -149,7 +151,7 @@ class NTPShaderOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
-            if context.scene.ntp_options.include_imports:
+            if self._include_imports:
                 self._file.write("import bpy, mathutils\n\n")
 
         if self.mode == 'ADDON':

--- a/shader/operator.py
+++ b/shader/operator.py
@@ -140,7 +140,7 @@ class NTPShaderOperator(NTP_Operator):
         #set up names to use in generated addon
         mat_var = clean_string(self.material_name)
         
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._outer = "\t\t"
             self._inner = "\t\t\t"
 
@@ -159,9 +159,9 @@ class NTPShaderOperator(NTP_Operator):
             if self._include_imports:
                 self._file.write("import bpy, mathutils\n\n")
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._create_material("\t\t")
-        elif self.mode == 'SCRIPT':
+        elif self._mode == 'SCRIPT':
             self._create_material("")   
         
         node_trees_to_process = self._topological_sort(self._base_node_tree)
@@ -169,7 +169,7 @@ class NTPShaderOperator(NTP_Operator):
         for node_tree in node_trees_to_process:
             self._process_node_tree(node_tree)
 
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._write("return {'FINISHED'}", self._outer)
             self._create_menu_func()
             self._create_register_func()
@@ -180,7 +180,7 @@ class NTPShaderOperator(NTP_Operator):
 
         self._file.close()
         
-        if self.mode == 'ADDON':
+        if self._mode == 'ADDON':
             self._zip_addon()
 
         self._report_finished("material")

--- a/shader/operator.py
+++ b/shader/operator.py
@@ -149,6 +149,8 @@ class NTPShaderOperator(NTP_Operator):
             self._write("def execute(self, context):", "\t")
         else:
             self._file = StringIO("")
+            if context.scene.ntp_options.include_imports:
+                self._file.write("import bpy, mathutils\n\n")
 
         if self.mode == 'ADDON':
             self._create_material("\t\t")

--- a/shader/operator.py
+++ b/shader/operator.py
@@ -128,7 +128,8 @@ class NTPShaderOperator(NTP_Operator):
         
 
     def execute(self, context):
-        self._setup_options(context.scene.ntp_options)
+        if not self._setup_options(context.scene.ntp_options):
+            return {'CANCELLED'}
         
         #find node group to replicate
         self._base_node_tree = bpy.data.materials[self.material_name].node_tree


### PR DESCRIPTION
# Features
* NodeToPython now exposes more options 
    * Script and addon mode have been reworked. They are now set in the options panel, and each mode exposes the appropriate settings
    * Option to include `import` statements (#101)
    * Including default, min, and max values for group inputs and outputs is now optional
    * Setting node dimensions is now optional
    * Input sockets can now be skipped if they are unavailable (option defaults to skip)
    * `bl_info` can now be filled in with user-set parameters
    * The generated add-on installation location can now be set using its Python ID, defaulting to `NODE_MT_add` (#80)

# Fixes
* Images without valid data now throw warnings and don't try to save in add-on mode

# Docs
* File permission explanation is now included in the manifest file