### PR TITLE
Manifest creation

### DIFF
--- a/compositor/operator.py
+++ b/compositor/operator.py
@@ -241,6 +241,8 @@ class NTPCompositorOperator(NTP_Operator):
             self._create_register_func()
             self._create_unregister_func()
             self._create_main_func()
+            if bpy.app.version >= (4, 2, 0):
+                self._create_manifest()
         else:
             context.window_manager.clipboard = self._file.getvalue()
 

--- a/geometry/operator.py
+++ b/geometry/operator.py
@@ -211,6 +211,8 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._create_register_func()
             self._create_unregister_func()
             self._create_main_func()
+            if bpy.app.version >= (4, 2, 0):
+                self._create_manifest()
         else:
             context.window_manager.clipboard = self._file.getvalue()
         self._file.close()

--- a/ntp_operator.py
+++ b/ntp_operator.py
@@ -394,8 +394,8 @@ class NTP_Operator(Operator):
             elif st == ST.IMAGE:
                 if self._addon_dir is not None and attr is not None:
                     if attr.source in {'FILE', 'GENERATED', 'TILED'}:
-                        self._save_image(attr)
-                        self._load_image(attr, f"{node_var}.{attr_name}")
+                        if self._save_image(attr):
+                            self._load_image(attr, f"{node_var}.{attr_name}")
             elif st == ST.IMAGE_USER:
                 self._image_user_settings(attr, f"{node_var}.{attr_name}")
             elif st == ST.SIM_OUTPUT_ITEMS:
@@ -782,8 +782,8 @@ class NTP_Operator(Operator):
                 elif input.bl_idname == 'NodeSocketImage':
                     img = input.default_value
                     if img is not None and self._addon_dir != None:  # write in a better way
-                        self._save_image(img)
-                        self._load_image(img, f"{socket_var}.default_value")
+                        if self._save_image(img):
+                            self._load_image(img, f"{socket_var}.default_value")
                     default_val = None
 
                 # materials
@@ -1040,7 +1040,7 @@ class NTP_Operator(Operator):
             self.report({'WARNING'}, (f"NodeToPython: Node tree dependency graph " 
                                     f"wasn't properly initialized"))
 
-    def _save_image(self, img: bpy.types.Image) -> None:
+    def _save_image(self, img: bpy.types.Image) -> bool:
         """
         Saves an image to an image directory of the add-on
 
@@ -1049,13 +1049,13 @@ class NTP_Operator(Operator):
         """
 
         if img is None:
-            return
+            return False
 
         img_str = img_to_py_str(img)
 
         if not img.has_data:
             self.report({'WARNING'}, f"{img_str} has no data")
-            return
+            return False
 
         # create image dir if one doesn't exist
         img_dir = os.path.join(self._addon_dir, IMAGE_DIR_NAME)
@@ -1067,6 +1067,7 @@ class NTP_Operator(Operator):
         img_path = f"{img_dir}/{img_str}"
         if not os.path.exists(img_path):
             img.save_render(img_path)
+        return True
 
     def _load_image(self, img: bpy.types.Image, img_var: str) -> None:
         """

--- a/options.py
+++ b/options.py
@@ -35,6 +35,7 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Generate necessary import statements",
         default = True
     )
+    
     # Addon properties
     dir_path : bpy.props.StringProperty(
         name = "Save Location",
@@ -74,6 +75,26 @@ class NTPOptions(bpy.types.PropertyGroup):
                       "(Preferences > Interface > Python tooltips) and "
                       "hovering over the desired menu",
         default="NODE_MT_add"
+    )
+    license: bpy.props.EnumProperty(
+        name="License",
+        items = [
+            ('SPDX:GPL-2.0-or-later', "GNU General Public License v2.0 or later", ""),
+            ('SPDX:GPL-3.0-or-later', "GNU General Public License v3.0 or later", ""),
+            ('SPDX:LGPL-2.1-or-later', "GNU Lesser General Public License v2.1 or later", ""),
+            ('SPDX:LGPL-3.0-or-later', "GNU Lesser General Public License v3.0 or later", ""),
+            ('SPDX:BSD-1-Clause', "BSD 1-Clause \"Simplified\" License", ""),
+            ('SPDX:BSD-2-Clause', "BSD 2-Clause \"Simplified\" License", ""),
+            ('SPDX:BSD-3-Clause', "BSD 3-Clause “New” or “Revised” License", ""),
+            ('SPDX:BSL-1.0', "Boost Software License 1.0", ""),
+            ('SPDX:MIT', "MIT License", ""),
+            ('SPDX:MIT-0', "MIT No Attribution", ""),
+            ('SPDX:MPL-2.0', "Mozilla Public License 2.0", ""),
+            ('SPDX:Pixar', "Pixar License", ""),
+            ('SPDX:Zlib', "Zlib License", ""),
+            ('OTHER', "Other", "")
+        ],
+        default = 'OTHER'
     )
     category: bpy.props.EnumProperty(
         name = "Category",
@@ -117,6 +138,7 @@ class NTPOptions(bpy.types.PropertyGroup):
         description="Custom category",
         default = ""
     )
+
 class NTPOptionsPanel(bpy.types.Panel):
     bl_label = "Options"
     bl_idname = "NODE_PT_ntp_options"
@@ -149,10 +171,13 @@ class NTPOptionsPanel(bpy.types.Panel):
         elif ntp_options.mode == 'ADDON':
             addon_options = [
                 "dir_path",
+                "name_override",
+                "description",
                 "author_name",
                 "version",
                 "location",
                 "menu_id",
+                "license",
                 "category"
             ]
             option_list += addon_options

--- a/shader/operator.py
+++ b/shader/operator.py
@@ -176,6 +176,8 @@ class NTPShaderOperator(NTP_Operator):
             self._create_register_func()
             self._create_unregister_func()
             self._create_main_func()
+            if bpy.app.version >= (4, 2, 0):
+                self._create_manifest()
         else:
             context.window_manager.clipboard = self._file.getvalue()
 

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,9 @@ def vec3_to_py_str(vec3) -> str:
     """
     return f"({vec3[0]}, {vec3[1]}, {vec3[2]})"
 
+def version_to_manifest_str(version) -> str:
+    return f"\"{version[0]}.{version[1]}.{version[2]}\""
+    
 def vec4_to_py_str(vec4) -> str:
     """
     Converts a 4D vector to a string usable by the add-on


### PR DESCRIPTION
# Features
* NodeToPython now writes out manifest files in add-on mode in Blender 4.2 and higher (#103, #104)

# Fixes
* Name Override and Description settings now exposed
* No longer attempts to load images if saving them was unsuccessful