### PR TITLE
change blender_version_max to 4.4.0 (for blender 4.3.x)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Node to Python", 
     "description": "Convert Blender node groups to a Python add-on!",
     "author": "Brendan Parmer",
-    "version": (3, 2, 0),
+    "version": (3, 3, 0),
     "blender": (3, 0, 0),
     "location": "Node", 
     "category": "Node",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -12,7 +12,7 @@ website = "https://github.com/BrendanParmer/NodeToPython"
 tags = ["Development", "Compositing", "Geometry Nodes", "Material", "Node"]
 
 blender_version_min = "4.2.0"
-blender_version_max = "4.3.0"
+blender_version_max = "4.4.0"
 
 license = [
     "SPDX:MIT",


### PR DESCRIPTION
I had problems with your new version v3.2 when trying to activate it in Blender 4.3.0 alpha. So I had to adjust the max_version.