### PR TITLE
Blender 4.3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+* [Brendan Parmer](https://github.com/BrendanParmer)
+* [Carlsu](https://github.com/carls3d)
+* [atticus-lv](https://github.com/atticus-lv)

--- a/NodeToPython/__init__.py
+++ b/NodeToPython/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Node to Python", 
     "description": "Convert Blender node groups to a Python add-on!",
     "author": "Brendan Parmer",
-    "version": (3, 2, 2),
+    "version": (3, 3, 0),
     "blender": (3, 0, 0),
     "location": "Node", 
     "category": "Node",

--- a/NodeToPython/__init__.py
+++ b/NodeToPython/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     "name": "Node to Python", 
     "description": "Convert Blender node groups to a Python add-on!",
     "author": "Brendan Parmer",
-    "version": (3, 2, 1),
+    "version": (3, 2, 2),
     "blender": (3, 0, 0),
     "location": "Node", 
     "category": "Node",

--- a/NodeToPython/blender_manifest.toml
+++ b/NodeToPython/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "node_to_python"
-version = "3.2.1"
+version = "3.2.2"
 name = "Node To Python"
 tagline = "Turn node groups into Python code"
 maintainer = "Brendan Parmer <brendanparmer+nodetopython@gmail.com>"

--- a/NodeToPython/blender_manifest.toml
+++ b/NodeToPython/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "node_to_python"
-version = "3.2.2"
+version = "3.3.0"
 name = "Node To Python"
 tagline = "Turn node groups into Python code"
 maintainer = "Brendan Parmer <brendanparmer+nodetopython@gmail.com>"
@@ -12,7 +12,7 @@ website = "https://github.com/BrendanParmer/NodeToPython"
 tags = ["Development", "Compositing", "Geometry Nodes", "Material", "Node"]
 
 blender_version_min = "4.2.0"
-blender_version_max = "4.3.0"
+blender_version_max = "4.4.0"
 
 license = [
     "SPDX:MIT",

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -107,7 +107,7 @@ class NTPCompositorOperator(NTP_Operator):
                    NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0)),
                    NTPNodeSetting("lift",  ST.VEC3,  max_version_=(3, 5, 0)),
                    NTPNodeSetting("lift",  ST.COLOR, min_version_=(3, 5, 0))]
-        else:
+        elif node.correction_method == 'OFFSET_POWER_SLOPE':
             lst = [NTPNodeSetting("correction_method", ST.ENUM),
                    NTPNodeSetting("offset", ST.VEC3,  max_version_=(3, 5, 0)),
                    NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0)),
@@ -116,6 +116,17 @@ class NTPCompositorOperator(NTP_Operator):
                    NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0)),
                    NTPNodeSetting("slope", ST.VEC3,  max_version_=(3, 5, 0)),
                    NTPNodeSetting("slope", ST.COLOR, min_version_=(3, 5, 0))]
+        elif node.correction_method == 'WHITEPOINT':
+            lst = [NTPNodeSetting("correction_method", ST.ENUM),
+                   NTPNodeSetting("input_temperature", ST.FLOAT),
+                   NTPNodeSetting("input_tint", ST.FLOAT),
+                   NTPNodeSetting("output_temperature", ST.FLOAT),
+                   NTPNodeSetting("output_tint", ST.FLOAT)]
+        else:
+            self.report({'ERROR'},
+                        f"Unknown color balance correction method "
+                        f"{enum_to_py_str(node.correction_method)}")
+            return
 
         color_balance_info = self._node_infos['CompositorNodeColorBalance']
         self._node_infos['CompositorNodeColorBalance'] = color_balance_info._replace(attributes_ = lst)

--- a/NodeToPython/geometry/node_tree.py
+++ b/NodeToPython/geometry/node_tree.py
@@ -4,8 +4,11 @@ from bpy.types import GeometryNodeTree
 if bpy.app.version >= (3, 6, 0):
     from bpy.types import GeometryNodeSimulationInput
 
-if bpy.app.version > (4, 0, 0):
+if bpy.app.version >= (4, 0, 0):
     from bpy.types import GeometryNodeRepeatInput
+
+if bpy.app.version >= (4, 3, 0):
+    from bpy.types import GeometryNodeForeachGeometryElementInput
 
 from ..ntp_node_tree import NTP_NodeTree
 
@@ -16,3 +19,5 @@ class NTP_GeoNodeTree(NTP_NodeTree):
             self.sim_inputs: list[GeometryNodeSimulationInput] = []
         if bpy.app.version >= (4, 0, 0):
             self.repeat_inputs: list[GeometryNodeRepeatInput] = []
+        if bpy.app.version >= (4, 3, 0):
+            self.foreach_element_inputs: list[GeometryNodeForeachGeometryElementInput] = []

--- a/NodeToPython/geometry/node_tree.py
+++ b/NodeToPython/geometry/node_tree.py
@@ -15,10 +15,10 @@ from ..ntp_node_tree import NTP_NodeTree
 class NTP_GeoNodeTree(NTP_NodeTree):
     def __init__(self, node_tree: GeometryNodeTree, var: str):
         super().__init__(node_tree, var)
-        self.zone_inputs_: dict[list[GeometryNode]] = {}
+        self.zone_inputs: dict[list[GeometryNode]] = {}
         if bpy.app.version >= (3, 6, 0):
-            self.zone_inputs_["GeometryNodeSimulationInput"] = []
+            self.zone_inputs["GeometryNodeSimulationInput"] = []
         if bpy.app.version >= (4, 0, 0):
-            self.zone_inputs_["GeometryNodeRepeatInput"] = []
+            self.zone_inputs["GeometryNodeRepeatInput"] = []
         if bpy.app.version >= (4, 3, 0):
-            self.zone_inputs_["GeometryNodeForeachGeometryElementInput"] = []
+            self.zone_inputs["GeometryNodeForeachGeometryElementInput"] = []

--- a/NodeToPython/geometry/node_tree.py
+++ b/NodeToPython/geometry/node_tree.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.types import GeometryNodeTree
+from bpy.types import GeometryNodeTree, GeometryNode
 
 if bpy.app.version >= (3, 6, 0):
     from bpy.types import GeometryNodeSimulationInput
@@ -15,9 +15,10 @@ from ..ntp_node_tree import NTP_NodeTree
 class NTP_GeoNodeTree(NTP_NodeTree):
     def __init__(self, node_tree: GeometryNodeTree, var: str):
         super().__init__(node_tree, var)
+        self.zone_inputs_: dict[list[GeometryNode]] = {}
         if bpy.app.version >= (3, 6, 0):
-            self.sim_inputs: list[GeometryNodeSimulationInput] = []
+            self.zone_inputs_["GeometryNodeSimulationInput"] = []
         if bpy.app.version >= (4, 0, 0):
-            self.repeat_inputs: list[GeometryNodeRepeatInput] = []
+            self.zone_inputs_["GeometryNodeRepeatInput"] = []
         if bpy.app.version >= (4, 3, 0):
-            self.foreach_element_inputs: list[GeometryNodeForeachGeometryElementInput] = []
+            self.zone_inputs_["GeometryNodeForeachGeometryElementInput"] = []

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -49,12 +49,8 @@ class NTPGeoNodesOperator(NTP_Operator):
                 self._group_io_settings(node, "output", ntp_nt)
                 ntp_nt.outputs_set = True
 
-        if node.bl_idname == 'GeometryNodeSimulationInput':
-            ntp_nt.sim_inputs.append(node)
-        elif node.bl_idname == 'GeometryNodeRepeatInput':
-            ntp_nt.repeat_inputs.append(node)
-        elif node.bl_idname == 'GeometryNodeForeachGeometryElementInput':
-            ntp_nt.foreach_element_inputs.append(node)
+        if node.bl_idname in ntp_nt.zone_inputs_:
+            ntp_nt.zone_inputs_[node.bl_idname].append(node)
         
         self._hide_hidden_sockets(node)
 
@@ -141,12 +137,8 @@ class NTPGeoNodesOperator(NTP_Operator):
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
 
-        if bpy.app.version >= (3, 6, 0):
-            self._process_zones(ntp_nt.sim_inputs)
-        if bpy.app.version >= (4, 0, 0):
-            self._process_zones(ntp_nt.repeat_inputs)
-        if bpy.app.version >= (4, 3, 0):
-            self._process_zones(ntp_nt.foreach_element_inputs)
+        for zone_list in ntp_nt.zone_inputs_.values():
+            self._process_zones(zone_list)
 
         #set look of nodes
         self._set_parents(node_tree)

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -49,14 +49,12 @@ class NTPGeoNodesOperator(NTP_Operator):
                 self._group_io_settings(node, "output", ntp_nt)
                 ntp_nt.outputs_set = True
 
-        if node.bl_idname in ntp_nt.zone_inputs_:
-            ntp_nt.zone_inputs_[node.bl_idname].append(node)
+        if node.bl_idname in ntp_nt.zone_inputs:
+            ntp_nt.zone_inputs[node.bl_idname].append(node)
         
         self._hide_hidden_sockets(node)
 
-        if node.bl_idname not in {'GeometryNodeSimulationInput', 
-                                  'GeometryNodeRepeatInput',
-                                  'GeometryNodeForeachGeometryElementInput'}:
+        if node.bl_idname not in ntp_nt.zone_inputs:
             self._set_socket_defaults(node)
 
     if bpy.app.version >= (3, 6, 0):
@@ -137,7 +135,7 @@ class NTPGeoNodesOperator(NTP_Operator):
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
 
-        for zone_list in ntp_nt.zone_inputs_.values():
+        for zone_list in ntp_nt.zone_inputs.values():
             self._process_zones(zone_list)
 
         #set look of nodes

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -51,14 +51,16 @@ class NTPGeoNodesOperator(NTP_Operator):
 
         if node.bl_idname == 'GeometryNodeSimulationInput':
             ntp_nt.sim_inputs.append(node)
-
         elif node.bl_idname == 'GeometryNodeRepeatInput':
             ntp_nt.repeat_inputs.append(node)
+        elif node.bl_idname == 'GeometryNodeForeachGeometryElementInput':
+            ntp_nt.foreach_element_inputs.append(node)
         
         self._hide_hidden_sockets(node)
 
         if node.bl_idname not in {'GeometryNodeSimulationInput', 
-                                  'GeometryNodeRepeatInput'}:
+                                  'GeometryNodeRepeatInput',
+                                  'GeometryNodeForeachGeometryElementInput'}:
             self._set_socket_defaults(node)
 
     if bpy.app.version >= (3, 6, 0):
@@ -143,6 +145,8 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._process_zones(ntp_nt.sim_inputs)
         if bpy.app.version >= (4, 0, 0):
             self._process_zones(ntp_nt.repeat_inputs)
+        if bpy.app.version >= (4, 3, 0):
+            self._process_zones(ntp_nt.foreach_element_inputs)
 
         #set look of nodes
         self._set_parents(node_tree)

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -48,12 +48,12 @@ class NTPNodeSetting(NamedTuple):
 	name_: str
 	st_: ST
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 3, 0)
+	max_version_: tuple = (4, 4, 0)
 
 class NodeInfo(NamedTuple):
 	attributes_: list[NTPNodeSetting]
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 3, 0)
+	max_version_: tuple = (4, 4, 0)
 
 node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeAlphaOver' : NodeInfo(
@@ -161,11 +161,17 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("gain", ST.COLOR, min_version_=(3, 5, 0)),
 			NTPNodeSetting("gamma", ST.VEC3, max_version_=(3, 5, 0)),
 			NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0)),
+			NTPNodeSetting("input_temperature", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("input_tint", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("input_whitepoint", ST.COLOR, min_version_=(4, 3, 0)),
 			NTPNodeSetting("lift", ST.VEC3, max_version_=(3, 5, 0)),
 			NTPNodeSetting("lift", ST.COLOR, min_version_=(3, 5, 0)),
 			NTPNodeSetting("offset", ST.VEC3, max_version_=(3, 5, 0)),
 			NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0)),
 			NTPNodeSetting("offset_basis", ST.FLOAT),
+			NTPNodeSetting("output_temperature", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("output_tint", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("output_whitepoint", ST.COLOR, min_version_=(4, 3, 0)),
 			NTPNodeSetting("power", ST.VEC3, max_version_=(3, 5, 0)),
 			NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0)),
 			NTPNodeSetting("slope", ST.VEC3, max_version_=(3, 5, 0)),
@@ -652,6 +658,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("file_slots", ST.FILE_SLOTS),
 			NTPNodeSetting("format", ST.IMAGE_FORMAT_SETTINGS),
 			NTPNodeSetting("layer_slots", ST.LAYER_SLOTS),
+			NTPNodeSetting("save_as_render", ST.BOOL, min_version_=(4, 3, 0)),
 		]
 	),
 
@@ -961,6 +968,13 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'FunctionNodeHashValue' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'FunctionNodeInputBool' : NodeInfo(
 		[
 			NTPNodeSetting("boolean", ST.BOOL),
@@ -1003,6 +1017,13 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'FunctionNodeIntegerMath' : NodeInfo(
+		[
+			NTPNodeSetting("operation", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'FunctionNodeInvertMatrix' : NodeInfo(
 		[],
 		min_version_ = (4, 2, 0)
@@ -1016,6 +1037,11 @@ node_settings : dict[str, NodeInfo] = {
 	'FunctionNodeLegacyRandomFloat' : NodeInfo(
 		[],
 		max_version_ = (3, 2, 0)
+	),
+
+	'FunctionNodeMatrixDeterminant' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
 	),
 
 	'FunctionNodeMatrixMultiply' : NodeInfo(
@@ -1119,7 +1145,9 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'FunctionNodeValueToString' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("data_type", ST.ENUM, min_version_=(4, 3, 0)),
+		]
 	),
 
 	'GeometryNodeAccumulateField' : NodeInfo(
@@ -1302,6 +1330,11 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'GeometryNodeCurvesToGreasePencil' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
+	),
+
 	'GeometryNodeCustomGroup' : NodeInfo(
 		[
 			NTPNodeSetting("node_tree", ST.NODE_TREE),
@@ -1423,6 +1456,22 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 1, 0)
 	),
 
+	'GeometryNodeForeachGeometryElementInput' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeForeachGeometryElementOutput' : NodeInfo(
+		[
+			NTPNodeSetting("active_generation_index", ST.INT),
+			NTPNodeSetting("active_input_index", ST.INT),
+			NTPNodeSetting("active_main_index", ST.INT),
+			NTPNodeSetting("domain", ST.ENUM),
+			NTPNodeSetting("inspection_index", ST.INT),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'GeometryNodeGeometryToInstance' : NodeInfo(
 		[],
 		min_version_ = (3, 1, 0)
@@ -1433,6 +1482,41 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("data_type", ST.ENUM),
 		],
 		min_version_ = (4, 1, 0)
+	),
+
+	'GeometryNodeGizmoDial' : NodeInfo(
+		[
+			NTPNodeSetting("color_id", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeGizmoLinear' : NodeInfo(
+		[
+			NTPNodeSetting("color_id", ST.ENUM),
+			NTPNodeSetting("draw_style", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeGizmoTransform' : NodeInfo(
+		[
+			NTPNodeSetting("use_rotation_x", ST.BOOL),
+			NTPNodeSetting("use_rotation_y", ST.BOOL),
+			NTPNodeSetting("use_rotation_z", ST.BOOL),
+			NTPNodeSetting("use_scale_x", ST.BOOL),
+			NTPNodeSetting("use_scale_y", ST.BOOL),
+			NTPNodeSetting("use_scale_z", ST.BOOL),
+			NTPNodeSetting("use_translation_x", ST.BOOL),
+			NTPNodeSetting("use_translation_y", ST.BOOL),
+			NTPNodeSetting("use_translation_z", ST.BOOL),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeGreasePencilToCurves' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
 	),
 
 	'GeometryNodeGridToMesh' : NodeInfo(
@@ -1456,6 +1540,21 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("extension", ST.ENUM),
 			NTPNodeSetting("interpolation", ST.ENUM),
 		]
+	),
+
+	'GeometryNodeImportOBJ' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeImportPLY' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeImportSTL' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
 	),
 
 	'GeometryNodeIndexOfNearest' : NodeInfo(
@@ -1976,6 +2075,13 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 1, 0)
 	),
 
+	'GeometryNodeMergeLayers' : NodeInfo(
+		[
+			NTPNodeSetting("mode", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'GeometryNodeMeshBoolean' : NodeInfo(
 		[
 			NTPNodeSetting("operation", ST.ENUM),
@@ -2305,6 +2411,11 @@ node_settings : dict[str, NodeInfo] = {
 		[]
 	),
 
+	'GeometryNodeSetGeometryName' : NodeInfo(
+		[],
+		min_version_ = (4, 3, 0)
+	),
+
 	'GeometryNodeSetID' : NodeInfo(
 		[]
 	),
@@ -2469,6 +2580,7 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeToolSetSelection' : NodeInfo(
 		[
 			NTPNodeSetting("domain", ST.ENUM),
+			NTPNodeSetting("selection_type", ST.ENUM, min_version_=(4, 3, 0)),
 		],
 		min_version_ = (4, 0, 0)
 	),
@@ -2536,6 +2648,13 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'GeometryNodeWarning' : NodeInfo(
+		[
+			NTPNodeSetting("warning_type", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'NodeFrame' : NodeInfo(
 		[
 			NTPNodeSetting("label_size", ST.INT),
@@ -2561,7 +2680,9 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'NodeReroute' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("socket_idname", ST.STRING, min_version_=(4, 3, 0)),
+		]
 	),
 
 	'ShaderNodeAddShader' : NodeInfo(
@@ -2635,6 +2756,14 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("model", ST.ENUM, min_version_=(4, 0, 0)),
 			NTPNodeSetting("parametrization", ST.ENUM),
 		]
+	),
+
+	'ShaderNodeBsdfMetallic' : NodeInfo(
+		[
+			NTPNodeSetting("distribution", ST.ENUM),
+			NTPNodeSetting("fresnel_type", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
 	),
 
 	'ShaderNodeBsdfPrincipled' : NodeInfo(
@@ -2989,6 +3118,13 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'ShaderNodeTexGabor' : NodeInfo(
+		[
+			NTPNodeSetting("gabor_type", ST.ENUM),
+		],
+		min_version_ = (4, 3, 0)
+	),
+
 	'ShaderNodeTexGradient' : NodeInfo(
 		[
 			NTPNodeSetting("gradient_type", ST.ENUM),
@@ -3168,7 +3304,9 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'ShaderNodeVolumeScatter' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("phase", ST.ENUM, min_version_=(4, 3, 0)),
+		]
 	),
 
 	'ShaderNodeWavelength' : NodeInfo(

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -9,6 +9,7 @@ class ST(Enum):
 	COLOR = auto()
 	ENUM = auto()
 	ENUM_SET = auto()
+	EULER = auto()
 	FLOAT = auto()
 	INT = auto()
 	STRING = auto()
@@ -17,26 +18,28 @@ class ST(Enum):
 	VEC3 = auto()
 	VEC4 = auto()
 	BAKE_ITEMS = auto()
+	CAPTURE_ATTRIBUTE_ITEMS = auto()
 	COLOR_RAMP = auto()
 	CURVE_MAPPING = auto()
 	ENUM_DEFINITION = auto()
+	ENUM_ITEM = auto()
+	FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
+	FOREACH_GEO_ELEMENT_INPUT_ITEMS = auto()
+	FOREACH_GEO_ELEMENT_MAIN_ITEMS = auto()
 	INDEX_SWITCH_ITEMS = auto()
+	MENU_SWITCH_ITEMS = auto()
 	NODE_TREE = auto()
 	REPEAT_OUTPUT_ITEMS = auto()
 	SIM_OUTPUT_ITEMS = auto()
 	IMAGE = auto()
 	IMAGE_USER = auto()
-	CAPTURE_ATTRIBUTE_ITEMS = auto()
 	CRYPTOMATTE_ENTRIES = auto()
-	ENUM_ITEM = auto()
-	EULER = auto()
 	FILE_SLOTS = auto()
 	FONT = auto()
 	IMAGE_FORMAT_SETTINGS = auto()
 	LAYER_SLOTS = auto()
 	MASK = auto()
 	MATERIAL = auto()
-	MENU_SWITCH_ITEMS = auto()
 	MOVIE_CLIP = auto()
 	OBJECT = auto()
 	PARTICLE_SYSTEM = auto()
@@ -1467,7 +1470,10 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("active_input_index", ST.INT),
 			NTPNodeSetting("active_main_index", ST.INT),
 			NTPNodeSetting("domain", ST.ENUM),
+			NTPNodeSetting("generation_items", ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS),
+			NTPNodeSetting("input_items", ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS),
 			NTPNodeSetting("inspection_index", ST.INT),
+			NTPNodeSetting("main_items", ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS),
 		],
 		min_version_ = (4, 3, 0)
 	),

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -1,13 +1,17 @@
 import bpy
 from bpy.types import Context, Operator
 from bpy.types import Node, NodeTree
-from bpy_types import bpy_types
 
 if bpy.app.version < (4, 0, 0):
     from bpy.types import NodeSocketInterface
 else:
     from bpy.types import NodeTreeInterfacePanel, NodeTreeInterfaceSocket
     from bpy.types import NodeTreeInterfaceItem
+
+if bpy.app.version >= (4, 3, 0):
+    from bpy.types import bpy_prop_array
+else:
+    from bpy_types.bpy_types import bpy_prop_array
 
 import datetime
 import os
@@ -574,7 +578,7 @@ class NTP_Operator(Operator):
                 dv = vec4_to_py_str(dv)
             elif type(dv) in {mathutils.Vector, mathutils.Euler}:
                 dv = vec3_to_py_str(dv)
-            elif type(dv) == bpy_types.bpy_prop_array:
+            elif type(dv) == bpy_prop_array:
                 dv = array_to_py_str(dv)
             elif type(dv) == str:
                 dv = str_to_py_str(dv)

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -1381,7 +1381,11 @@ class NTP_Operator(Operator):
             color_tag_str = enum_to_py_str(node_tree.color_tag)
             self._write(f"{nt_var}.color_tag = {color_tag_str}")
             desc_str = str_to_py_str(node_tree.description)
-            self._write(f"{nt_var}.description = {desc_str}\n")
+            self._write(f"{nt_var}.description = {desc_str}")
+        if bpy.app.version >= (4, 3, 0):
+            default_width = node_tree.default_group_node_width
+            self._write(f"{nt_var}.default_group_node_width = {default_width}")
+        self._write("\n")
 
     def _hide_hidden_sockets(self, node: Node) -> None:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -8,10 +8,7 @@ else:
     from bpy.types import NodeTreeInterfacePanel, NodeTreeInterfaceSocket
     from bpy.types import NodeTreeInterfaceItem
 
-if bpy.app.version >= (4, 3, 0):
-    from bpy.types import bpy_prop_array
-else:
-    from bpy_types.bpy_types import bpy_prop_array
+from bpy.types import bpy_prop_array
 
 import datetime
 import os

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -339,8 +339,9 @@ class NTP_Operator(Operator):
 
         # Warning propagation
         if bpy.app.version >= (4, 3, 0):
-            self._write(f"{node_var}.warning_propagation = "
-                        f"{enum_to_py_str(node.warning_propagation)}")
+            if node.warning_propagation != 'ALL':
+                self._write(f"{node_var}.warning_propagation = "
+                            f"{enum_to_py_str(node.warning_propagation)}")
         return node_var
 
     def _set_settings_defaults(self, node: Node) -> None:

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -446,6 +446,12 @@ class NTP_Operator(Operator):
                 self._capture_attribute_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.MENU_SWITCH_ITEMS:
                 self._menu_switch_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS:
+                self._foreach_geo_element_generation_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS:
+                self._foreach_geo_element_input_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS:
+                self._foreach_geo_element_main_items(attr, f"{node_var}.{attr_name}")
 
     if bpy.app.version < (4, 0, 0):
         def _set_group_socket_defaults(self, socket_interface: NodeSocketInterface,
@@ -1276,6 +1282,43 @@ class NTP_Operator(Operator):
                 self._write(f"{menu_switch_items_str}.new({name_str})")
                 desc_str = str_to_py_str(item.description)
                 self._write(f"{menu_switch_items_str}[{i}].description = {desc_str}")
+
+    if bpy.app.version >= (4, 3, 0):
+        def _foreach_geo_element_generation_items(self,
+            generation_items: bpy.types.NodeGeometryForeachGeometryElementGenerationItems,
+            generation_items_str: str
+        ) -> None:
+            self._write(f"{generation_items_str}.clear()")
+            for i, item in enumerate(generation_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write(f"{generation_items_str}.new({socket_type}, {name_str})")
+                
+                item_str = f"{generation_items_str}[{i}]"
+                
+                ad = enum_to_py_str(item.domain)
+                self._write(f"{item_str}.domain = {ad}")
+
+        def _foreach_geo_element_input_items(self,
+            input_items: bpy.types.NodeGeometryForeachGeometryElementInputItems,
+            input_items_str: str
+        ) -> None:
+            self._write(f"{input_items_str}.clear()")
+            for i, item in enumerate(input_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write(f"{input_items_str}.new({socket_type}, {name_str})")
+
+        def _foreach_geo_element_main_items(self,
+            main_items: bpy.types.NodeGeometryForeachGeometryElementMainItems,
+            main_items_str: str
+        ) -> None:
+            self._write(f"{main_items_str}.clear()")
+            for i, item in enumerate(main_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write(f"{main_items_str}.new({socket_type}, {name_str})")
+
 
     def _set_parents(self, node_tree: NodeTree) -> None:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -339,6 +339,11 @@ class NTP_Operator(Operator):
         # hide
         if node.hide:
             self._write(f"{node_var}.hide = True")
+
+        # Warning propagation
+        if bpy.app.version >= (4, 3, 0):
+            self._write(f"{node_var}.warning_propagation = "
+                        f"{enum_to_py_str(node.warning_propagation)}")
         return node_var
 
     def _set_settings_defaults(self, node: Node) -> None:

--- a/NodeToPython/utils.py
+++ b/NodeToPython/utils.py
@@ -1,6 +1,10 @@
 import bpy
-from bpy_types import bpy_types
 import mathutils
+
+if bpy.app.version >= (4, 3, 0):
+    from bpy.types import bpy_prop_array
+else:
+    from bpy_types.bpy_types import bpy_prop_array
 
 import keyword
 import re
@@ -106,7 +110,7 @@ def vec4_to_py_str(vec4) -> str:
     """
     return f"({vec4[0]}, {vec4[1]}, {vec4[2]}, {vec4[3]})"
 
-def array_to_py_str(array: bpy_types.bpy_prop_array) -> str:
+def array_to_py_str(array: bpy_prop_array) -> str:
     """
     Converts a bpy_prop_array into a string
 

--- a/NodeToPython/utils.py
+++ b/NodeToPython/utils.py
@@ -1,10 +1,8 @@
 import bpy
 import mathutils
 
-if bpy.app.version >= (4, 3, 0):
-    from bpy.types import bpy_prop_array
-else:
-    from bpy_types.bpy_types import bpy_prop_array
+
+from bpy.types import bpy_prop_array
 
 import keyword
 import re

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,10 @@ Blender's node-based editors are powerful, yet accessible tools, and I wanted to
 NodeToPython v3.2.1 is supported for Blender 3.0 - 4.2 on Windows, macOS, and Linux.
 
 ## Installation
+### Blender Extensions Platform
+NodeToPython is now on the official [Blender Extensions Platform](https://extensions.blender.org/add-ons/node-to-python/)! See https://extensions.blender.org/about/ for installation instructions and more info. 
+
+### GitHub
 1. Download the `NodeToPython.zip` file from the [latest release](https://github.com/BrendanParmer/NodeToPython/releases)
     * If you download other options, you'll need to rename the zip and the first folder to "NodeToPython" so Blender can properly import the add-on
 2. In Blender, navigate to `Edit > Preferences > Add-ons`

--- a/tools/node_settings_generator/types_utils.py
+++ b/tools/node_settings_generator/types_utils.py
@@ -9,6 +9,7 @@ class ST(Enum):
     COLOR       = auto()
     ENUM        = auto()
     ENUM_SET    = auto()
+    EULER       = auto()
     FLOAT       = auto()
     INT         = auto()
     STRING      = auto()
@@ -18,31 +19,33 @@ class ST(Enum):
     VEC4        = auto()
     
     # Special settings
-    BAKE_ITEMS          = auto()
-    COLOR_RAMP          = auto()
-    CURVE_MAPPING       = auto()
-    ENUM_DEFINITION     = auto()
-    INDEX_SWITCH_ITEMS  = auto()
-    NODE_TREE           = auto()
-    REPEAT_OUTPUT_ITEMS = auto()
-    SIM_OUTPUT_ITEMS    = auto()
+    BAKE_ITEMS                           = auto()
+    CAPTURE_ATTRIBUTE_ITEMS              = auto()
+    COLOR_RAMP                           = auto()
+    CURVE_MAPPING                        = auto()
+    ENUM_DEFINITION                      = auto()
+    ENUM_ITEM                            = auto()
+    FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
+    FOREACH_GEO_ELEMENT_INPUT_ITEMS      = auto()
+    FOREACH_GEO_ELEMENT_MAIN_ITEMS       = auto()
+    INDEX_SWITCH_ITEMS                   = auto()
+    MENU_SWITCH_ITEMS                    = auto()
+    NODE_TREE                            = auto()
+    REPEAT_OUTPUT_ITEMS                  = auto()
+    SIM_OUTPUT_ITEMS                     = auto()
 
     # Image
     IMAGE       = auto() #needs refactor
     IMAGE_USER  = auto() #needs refactor
 
     # Currently unimplemented
-    CAPTURE_ATTRIBUTE_ITEMS     = auto() #TODO NTP v3.2
     CRYPTOMATTE_ENTRIES         = auto()
-    ENUM_ITEM                   = auto() #TODO NTP v3.2
-    EULER                       = auto() #TODO NTP v3.2
     FILE_SLOTS                  = auto()
     FONT                        = auto()
     IMAGE_FORMAT_SETTINGS       = auto()
     LAYER_SLOTS                 = auto()
     MASK                        = auto()
     MATERIAL                    = auto() #TODO asset library
-    MENU_SWITCH_ITEMS           = auto() #TODO NTP v3.2
     MOVIE_CLIP                  = auto() 
     OBJECT                      = auto() #TODO asset library
     PARTICLE_SYSTEM             = auto()
@@ -59,6 +62,9 @@ READ_ONLY_TYPES : set[ST] = {
     ST.CURVE_MAPPING,
     ST.ENUM_DEFINITION,
     ST.FILE_SLOTS,
+    ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS,
+    ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS,
+    ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS,
     ST.IMAGE_FORMAT_SETTINGS,
     ST.IMAGE_USER,
     ST.INDEX_SWITCH_ITEMS,
@@ -100,6 +106,9 @@ doc_to_NTP_type_dict : dict[str, ST] = {
     "NodeEnumItem" : ST.ENUM_ITEM,
     "NodeGeometryBakeItems" : ST.BAKE_ITEMS,
     "NodeGeometryCaptureAttributeItems" : ST.CAPTURE_ATTRIBUTE_ITEMS,
+    "NodeGeometryForeachGeometryElementGenerationItems": ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS,
+    "NodeGeometryForeachGeometryElementInputItems" : ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS,
+    "NodeGeometryForeachGeometryElementMainItems": ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS,
     "NodeGeometryRepeatOutputItems" : ST.REPEAT_OUTPUT_ITEMS,
     "NodeGeometrySimulationOutputItems" : ST.SIM_OUTPUT_ITEMS,
     "NodeIndexSwitchItems" : ST.INDEX_SWITCH_ITEMS,


### PR DESCRIPTION
**Features**
* New 4.3 nodes and updates
    * For each zones
        * `GeometryNodeForeachGeometryElementInput`
        * `GeometryNodeForeachElementOutput`
    * Gizmos
        * `GeometryNodeGizmoDial`
        * `GeometryNodeGizmoLinear`
        * `GeometryNodeGizmoTransform`
    * Grease Pencil 
        * `GeometryNodeCurvesToGreasePencil`
        * `GeometryNodeGreasePencilToCurves`
        * `GeometryNodeMergeLayers`
    * Utilities
        * `FunctionNodeHashValue`
        * `FunctionNodeIntegerMath` 
        * `FunctionNodeMatrixDeterminant`
        * `GeometryNodeSetGeometryName`
        * `GeometryNodeWarning`
        * `FunctionNodeValueToString` has new setting `data_type`
        * `GeometryNodeToolSetSelection` has new setting `selection_type`
        * `NodeReroute` has new setting `socket_idname`
    * Experimental Import Nodes
        * `GeometryNodeImportOBJ`
        * `GeometryNodeImportPLY`
        * `GeometryNodeImportSTL`
    * Shader
        * `ShaderNodeBsdfMetallic`
        * `ShaderNodeTexGabor`
        * `ShaderNodeVolumeScatter` has new attribute `phase`
* Node trees can now set a default group width
* Nodes can now set their warning propagation
* Added whitepoint correction method to `CompositorNodeColorBalance`
    * Now throws an error if an unknown correction method is specified 
* Added Foreach Geometry Element zones

**Fixes**
* Update `bpy_props_array` import
* Import for `GeometryNodeRepeatInput` includes Blender 4.0.0

**Tools**
* Downloading bpy documentation is a little more stable now
* Added new foreach element types to `ST`

**Other**
* NTP version bumped to `v3.3.0`
* Blender max version bumped to 4.4