### PR TITLE
Blender 4.4

### DIFF
--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -24,8 +24,8 @@ class NTPCompositorOperator(NTP_Operator):
     compositor_name: bpy.props.StringProperty(name="Node Group")
     is_scene : bpy.props.BoolProperty(name="Is Scene", description="Blender stores compositing node trees differently for scenes and in groups")
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._node_infos = node_settings
         for name in COMP_OP_RESERVED_NAMES:
             self._used_vars[name] = 0

--- a/NodeToPython/compositor/ui.py
+++ b/NodeToPython/compositor/ui.py
@@ -11,6 +11,9 @@ class NTPCompositorPanel(Panel):
     bl_context = ''
     bl_category = "NodeToPython"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
     @classmethod
     def poll(cls, context):
         return True

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -23,8 +23,9 @@ class NTPGeoNodesOperator(NTP_Operator):
 
     geo_nodes_group_name: bpy.props.StringProperty(name="Node Group")
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
         self._node_infos = node_settings
         for name in GEO_OP_RESERVED_NAMES:
             self._used_vars[name] = 0

--- a/NodeToPython/geometry/ui.py
+++ b/NodeToPython/geometry/ui.py
@@ -12,6 +12,9 @@ class NTPGeoNodesPanel(Panel):
     bl_context = ''
     bl_category = "NodeToPython"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
     @classmethod
     def poll(cls, context):
         return True

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -33,6 +33,7 @@ class ST(Enum):
 	SIM_OUTPUT_ITEMS = auto()
 	IMAGE = auto()
 	IMAGE_USER = auto()
+	COLLECTION = auto()
 	CRYPTOMATTE_ENTRIES = auto()
 	FILE_SLOTS = auto()
 	FONT = auto()
@@ -51,12 +52,12 @@ class NTPNodeSetting(NamedTuple):
 	name_: str
 	st_: ST
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 4, 0)
+	max_version_: tuple = (4, 5, 0)
 
 class NodeInfo(NamedTuple):
 	attributes_: list[NTPNodeSetting]
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 4, 0)
+	max_version_: tuple = (4, 5, 0)
 
 node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeAlphaOver' : NodeInfo(
@@ -378,6 +379,7 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeDenoise' : NodeInfo(
 		[
 			NTPNodeSetting("prefilter", ST.ENUM),
+			NTPNodeSetting("quality", ST.ENUM, min_version_=(4, 4, 0)),
 			NTPNodeSetting("use_hdr", ST.BOOL),
 		]
 	),
@@ -882,6 +884,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("center_x", ST.FLOAT, max_version_=(4, 2, 0)),
 			NTPNodeSetting("center_y", ST.FLOAT, max_version_=(4, 2, 0)),
 			NTPNodeSetting("tile_order", ST.ENUM, max_version_=(4, 2, 0)),
+			NTPNodeSetting("ui_shortcut", ST.INT, min_version_=(4, 4, 0)),
 			NTPNodeSetting("use_alpha", ST.BOOL),
 		]
 	),
@@ -963,6 +966,11 @@ node_settings : dict[str, NodeInfo] = {
 	'FunctionNodeEulerToRotation' : NodeInfo(
 		[],
 		min_version_ = (4, 0, 0)
+	),
+
+	'FunctionNodeFindInString' : NodeInfo(
+		[],
+		min_version_ = (4, 4, 0)
 	),
 
 	'FunctionNodeFloatToInt' : NodeInfo(
@@ -1581,6 +1589,13 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (4, 1, 0)
 	),
 
+	'GeometryNodeInputCollection' : NodeInfo(
+		[
+			NTPNodeSetting("collection", ST.COLLECTION),
+		],
+		min_version_ = (4, 4, 0)
+	),
+
 	'GeometryNodeInputCurveHandlePositions' : NodeInfo(
 		[]
 	),
@@ -1682,7 +1697,16 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'GeometryNodeInputNormal' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("legacy_corner_normals", ST.BOOL, min_version_=(4, 4, 0)),
+		]
+	),
+
+	'GeometryNodeInputObject' : NodeInfo(
+		[
+			NTPNodeSetting("object", ST.OBJECT),
+		],
+		min_version_ = (4, 4, 0)
 	),
 
 	'GeometryNodeInputPosition' : NodeInfo(
@@ -2282,6 +2306,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeResampleCurve' : NodeInfo(
 		[
+			NTPNodeSetting("keep_last_segment", ST.BOOL, min_version_=(4, 4, 0)),
 			NTPNodeSetting("mode", ST.ENUM),
 		]
 	),

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -229,6 +229,9 @@ class NTP_Operator(Operator):
         """
         self._idname = idname
         self._write(f"class {self._class_name}(bpy.types.Operator):", 0)
+        self._write("def __init__(self, *args, **kwargs):", 1)
+        self._write("super().__init__(*args, **kwargs)\n", 2)
+
         self._write(f"bl_idname = \"node.{idname}\"", 1)
         self._write(f"bl_label = {str_to_py_str(label)}", 1)
         self._write("bl_options = {\'REGISTER\', \'UNDO\'}\n", 1)

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -64,8 +64,8 @@ class NTP_Operator(Operator):
             bpy.types.NodeTreeInterfaceSocketTexture
         }
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         # Write functions after nodes are mostly initialized and linked up
         self._write_after_links: list[Callable] = []

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -755,6 +755,7 @@ class NTP_Operator(Operator):
                 processed items, so none are done twice
             ntp_nt (NTP_NodeTree): owner of the socket
             """
+            
             if parent is None:
                 items = ntp_nt.node_tree.interface.items_tree
             else:
@@ -774,6 +775,14 @@ class NTP_Operator(Operator):
                 elif item.item_type == 'PANEL':
                     self._create_panel(item, panel_dict, items_processed,
                                        parent, ntp_nt)
+                    if bpy.app.version >= (4, 4, 0) and parent is not None:
+                        nt_var = self._node_tree_vars[ntp_nt.node_tree]
+                        interface_var = f"{nt_var}.interface"
+                        panel_var = panel_dict[item]
+                        parent_var = panel_dict[parent]
+                        self._write(f"{interface_var}.move_to_parent("
+                                    f"{panel_var}, {parent_var}, {item.index})")
+                                    
 
         def _tree_interface_settings(self, ntp_nt: NTP_NodeTree) -> None:
             """

--- a/NodeToPython/options.py
+++ b/NodeToPython/options.py
@@ -4,6 +4,10 @@ class NTPOptions(bpy.types.PropertyGroup):
     """
     Property group used during conversion of node group to python
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
     # General properties
     mode: bpy.props.EnumProperty(
         name = "Mode",
@@ -169,6 +173,9 @@ class NTPOptionsPanel(bpy.types.Panel):
     bl_region_type = 'UI'
     bl_context = ''
     bl_category = "NodeToPython"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def poll(cls, context):

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -21,8 +21,8 @@ class NTPShaderOperator(NTP_Operator):
     #TODO: add option for general shader node groups
     material_name: bpy.props.StringProperty(name="Node Group")
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._node_infos = node_settings
         for name in SHADER_OP_RESERVED_NAMES:
             self._used_vars[name] = 0

--- a/NodeToPython/shader/ui.py
+++ b/NodeToPython/shader/ui.py
@@ -11,6 +11,9 @@ class NTPShaderPanel(Panel):
     bl_context = ''
     bl_category = "NodeToPython"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
     @classmethod
     def poll(cls, context):
         return True

--- a/tools/node_settings_generator/types_utils.py
+++ b/tools/node_settings_generator/types_utils.py
@@ -39,6 +39,7 @@ class ST(Enum):
     IMAGE_USER  = auto() #needs refactor
 
     # Currently unimplemented
+    COLLECTION                  = auto()
     CRYPTOMATTE_ENTRIES         = auto()
     FILE_SLOTS                  = auto()
     FONT                        = auto()
@@ -78,6 +79,7 @@ doc_to_NTP_type_dict : dict[str, ST] = {
     "" : "",
     "bpy_prop_collection of CryptomatteEntry": ST.CRYPTOMATTE_ENTRIES,
     "boolean" : ST.BOOL,
+    "Collection" : ST.COLLECTION,
     "ColorMapping" : None, # Always read-only
     "ColorRamp" : ST.COLOR_RAMP,
     "CompositorNodeOutputFileFileSlots" : ST.FILE_SLOTS,


### PR DESCRIPTION
#142

# Features
* Collections now have a setting type
* New node settings for Blender 4.4
    * New nodes `FunctionNodeFindInString`, `GeometryNodeInputCollection`, `GeometryNodeInputObject`
    * `CompositorNodeDenoise` has a new `quality` setting
    * `CompositorNodeViewer` now sets the new `ui_shortcut` option
    * `GeometryNodeInputNormal` now has a new `legacy_corner_normals` setting to revert to pre-Blender 4.4 behavior
    * `GeometryNodeResampleCurve` has a new `keep_last_segment` option
* Subpanels are now supported

# Fixes
* NodeToPython now explicitly calls Blender class parent constructors in all operators and UI classes
* Generated addons now explicitly call the Blender class parent constructor

# Tools
* Node settings generator now supports Collection setting types