### PR TITLE
Blender v4.5

### DIFF
--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -93,45 +93,46 @@ class NTPCompositorOperator(NTP_Operator):
                 self._write(f"{ntp_nt.var}.{bool_setting} = True")
         
 
-    def _set_color_balance_settings(self, node: CompositorNodeColorBalance
-                                   ) -> None:
-        """
-        Sets the color balance settings so we only set the active variables,
-        preventing conflict
+    if bpy.app.version < (4, 5, 0):
+        def _set_color_balance_settings(self, node: CompositorNodeColorBalance
+                                    ) -> None:
+            """
+            Sets the color balance settings so we only set the active variables,
+            preventing conflict
 
-        node (CompositorNodeColorBalance): the color balance node
-        """
-        if node.correction_method == 'LIFT_GAMMA_GAIN':
-            lst = [NTPNodeSetting("correction_method", ST.ENUM),                 
-                   NTPNodeSetting("gain",  ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("gain",  ST.COLOR, min_version_=(3, 5, 0)),
-                   NTPNodeSetting("gamma", ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0)),
-                   NTPNodeSetting("lift",  ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("lift",  ST.COLOR, min_version_=(3, 5, 0))]
-        elif node.correction_method == 'OFFSET_POWER_SLOPE':
-            lst = [NTPNodeSetting("correction_method", ST.ENUM),
-                   NTPNodeSetting("offset", ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0)),
-                   NTPNodeSetting("offset_basis", ST.FLOAT),
-                   NTPNodeSetting("power", ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0)),
-                   NTPNodeSetting("slope", ST.VEC3,  max_version_=(3, 5, 0)),
-                   NTPNodeSetting("slope", ST.COLOR, min_version_=(3, 5, 0))]
-        elif node.correction_method == 'WHITEPOINT':
-            lst = [NTPNodeSetting("correction_method", ST.ENUM),
-                   NTPNodeSetting("input_temperature", ST.FLOAT),
-                   NTPNodeSetting("input_tint", ST.FLOAT),
-                   NTPNodeSetting("output_temperature", ST.FLOAT),
-                   NTPNodeSetting("output_tint", ST.FLOAT)]
-        else:
-            self.report({'ERROR'},
-                        f"Unknown color balance correction method "
-                        f"{enum_to_py_str(node.correction_method)}")
-            return
+            node (CompositorNodeColorBalance): the color balance node
+            """
+            if node.correction_method == 'LIFT_GAMMA_GAIN':
+                lst = [NTPNodeSetting("correction_method", ST.ENUM),                 
+                    NTPNodeSetting("gain",  ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("gain",  ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+                    NTPNodeSetting("gamma", ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+                    NTPNodeSetting("lift",  ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("lift",  ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0))]
+            elif node.correction_method == 'OFFSET_POWER_SLOPE':
+                lst = [NTPNodeSetting("correction_method", ST.ENUM),
+                    NTPNodeSetting("offset", ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+                    NTPNodeSetting("offset_basis", ST.FLOAT),
+                    NTPNodeSetting("power", ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+                    NTPNodeSetting("slope", ST.VEC3,  max_version_=(3, 5, 0)),
+                    NTPNodeSetting("slope", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0))]
+            elif node.correction_method == 'WHITEPOINT':
+                lst = [NTPNodeSetting("correction_method", ST.ENUM, max_version_=(4, 5, 0)),
+                    NTPNodeSetting("input_temperature", ST.FLOAT, max_version_=(4, 5, 0)),
+                    NTPNodeSetting("input_tint", ST.FLOAT, max_version_=(4, 5, 0)),
+                    NTPNodeSetting("output_temperature", ST.FLOAT, max_version_=(4, 5, 0)),
+                    NTPNodeSetting("output_tint", ST.FLOAT, max_version_=(4, 5, 0))]
+            else:
+                self.report({'ERROR'},
+                            f"Unknown color balance correction method "
+                            f"{enum_to_py_str(node.correction_method)}")
+                return
 
-        color_balance_info = self._node_infos['CompositorNodeColorBalance']
-        self._node_infos['CompositorNodeColorBalance'] = color_balance_info._replace(attributes_ = lst)
+            color_balance_info = self._node_infos['CompositorNodeColorBalance']
+            self._node_infos['CompositorNodeColorBalance'] = color_balance_info._replace(attributes_ = lst)
 
     def _process_node(self, node: Node, ntp_nt: NTP_NodeTree):
         """
@@ -143,8 +144,9 @@ class NTPCompositorOperator(NTP_Operator):
         """
         node_var: str = self._create_node(node, ntp_nt.var)
         
-        if node.bl_idname == 'CompositorNodeColorBalance':
-            self._set_color_balance_settings(node)
+        if bpy.app.version < (4, 5, 0):
+            if node.bl_idname == 'CompositorNodeColorBalance':
+                self._set_color_balance_settings(node)
 
         self._set_settings_defaults(node)
         self._hide_hidden_sockets(node)

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -52,88 +52,88 @@ class NTPNodeSetting(NamedTuple):
 	name_: str
 	st_: ST
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 5, 0)
+	max_version_: tuple = (5, 0, 0)
 
 class NodeInfo(NamedTuple):
 	attributes_: list[NTPNodeSetting]
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (4, 5, 0)
+	max_version_: tuple = (5, 0, 0)
 
 node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeAlphaOver' : NodeInfo(
 		[
-			NTPNodeSetting("premul", ST.FLOAT),
-			NTPNodeSetting("use_premultiply", ST.BOOL),
+			NTPNodeSetting("premul", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_premultiply", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeAntiAliasing' : NodeInfo(
 		[
-			NTPNodeSetting("contrast_limit", ST.FLOAT),
-			NTPNodeSetting("corner_rounding", ST.FLOAT),
-			NTPNodeSetting("threshold", ST.FLOAT),
+			NTPNodeSetting("contrast_limit", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("corner_rounding", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBilateralblur' : NodeInfo(
 		[
-			NTPNodeSetting("iterations", ST.INT),
-			NTPNodeSetting("sigma_color", ST.FLOAT),
-			NTPNodeSetting("sigma_space", ST.FLOAT),
+			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("sigma_color", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("sigma_space", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBlur' : NodeInfo(
 		[
-			NTPNodeSetting("aspect_correction", ST.ENUM),
-			NTPNodeSetting("factor", ST.FLOAT),
-			NTPNodeSetting("factor_x", ST.FLOAT),
-			NTPNodeSetting("factor_y", ST.FLOAT),
+			NTPNodeSetting("aspect_correction", ST.ENUM, max_version_=(4, 5, 0)),
+			NTPNodeSetting("factor", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("factor_x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("factor_y", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("filter_type", ST.ENUM),
-			NTPNodeSetting("size_x", ST.INT),
-			NTPNodeSetting("size_y", ST.INT),
-			NTPNodeSetting("use_bokeh", ST.BOOL),
-			NTPNodeSetting("use_extended_bounds", ST.BOOL),
-			NTPNodeSetting("use_gamma_correction", ST.BOOL),
-			NTPNodeSetting("use_relative", ST.BOOL),
-			NTPNodeSetting("use_variable_size", ST.BOOL),
+			NTPNodeSetting("size_x", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("size_y", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_bokeh", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_extended_bounds", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_gamma_correction", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_relative", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_variable_size", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBokehBlur' : NodeInfo(
 		[
-			NTPNodeSetting("blur_max", ST.FLOAT),
-			NTPNodeSetting("use_extended_bounds", ST.BOOL),
-			NTPNodeSetting("use_variable_size", ST.BOOL),
+			NTPNodeSetting("blur_max", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_extended_bounds", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_variable_size", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBokehImage' : NodeInfo(
 		[
-			NTPNodeSetting("angle", ST.FLOAT),
-			NTPNodeSetting("catadioptric", ST.FLOAT),
-			NTPNodeSetting("flaps", ST.INT),
-			NTPNodeSetting("rounding", ST.FLOAT),
-			NTPNodeSetting("shift", ST.FLOAT),
+			NTPNodeSetting("angle", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("catadioptric", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("flaps", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("rounding", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shift", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBoxMask' : NodeInfo(
 		[
 			NTPNodeSetting("height", ST.FLOAT, max_version_=(4, 2, 0)),
-			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0)),
+			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("mask_type", ST.ENUM),
-			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0)),
-			NTPNodeSetting("rotation", ST.FLOAT),
+			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("rotation", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("width", ST.FLOAT, max_version_=(4, 2, 0)),
-			NTPNodeSetting("x", ST.FLOAT),
-			NTPNodeSetting("y", ST.FLOAT),
+			NTPNodeSetting("x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("y", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeBrightContrast' : NodeInfo(
 		[
-			NTPNodeSetting("use_premultiply", ST.BOOL),
+			NTPNodeSetting("use_premultiply", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -141,20 +141,20 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("color_space", ST.ENUM),
 			NTPNodeSetting("limit_channel", ST.ENUM),
-			NTPNodeSetting("limit_max", ST.FLOAT),
+			NTPNodeSetting("limit_max", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("limit_method", ST.ENUM),
-			NTPNodeSetting("limit_min", ST.FLOAT),
+			NTPNodeSetting("limit_min", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("matte_channel", ST.ENUM),
 		]
 	),
 
 	'CompositorNodeChromaMatte' : NodeInfo(
 		[
-			NTPNodeSetting("gain", ST.FLOAT),
-			NTPNodeSetting("lift", ST.FLOAT),
-			NTPNodeSetting("shadow_adjust", ST.FLOAT),
-			NTPNodeSetting("threshold", ST.FLOAT),
-			NTPNodeSetting("tolerance", ST.FLOAT),
+			NTPNodeSetting("gain", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("lift", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadow_adjust", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -162,62 +162,62 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("correction_method", ST.ENUM),
 			NTPNodeSetting("gain", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("gain", ST.COLOR, min_version_=(3, 5, 0)),
+			NTPNodeSetting("gain", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("gamma", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0)),
-			NTPNodeSetting("input_temperature", ST.FLOAT, min_version_=(4, 3, 0)),
-			NTPNodeSetting("input_tint", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("gamma", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("input_temperature", ST.FLOAT, min_version_=(4, 3, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("input_tint", ST.FLOAT, min_version_=(4, 3, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("input_whitepoint", ST.COLOR, min_version_=(4, 3, 0)),
 			NTPNodeSetting("lift", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("lift", ST.COLOR, min_version_=(3, 5, 0)),
+			NTPNodeSetting("lift", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("offset", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0)),
-			NTPNodeSetting("offset_basis", ST.FLOAT),
-			NTPNodeSetting("output_temperature", ST.FLOAT, min_version_=(4, 3, 0)),
-			NTPNodeSetting("output_tint", ST.FLOAT, min_version_=(4, 3, 0)),
+			NTPNodeSetting("offset", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("offset_basis", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("output_temperature", ST.FLOAT, min_version_=(4, 3, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("output_tint", ST.FLOAT, min_version_=(4, 3, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("output_whitepoint", ST.COLOR, min_version_=(4, 3, 0)),
 			NTPNodeSetting("power", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0)),
+			NTPNodeSetting("power", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("slope", ST.VEC3, max_version_=(3, 5, 0)),
-			NTPNodeSetting("slope", ST.COLOR, min_version_=(3, 5, 0)),
+			NTPNodeSetting("slope", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeColorCorrection' : NodeInfo(
 		[
-			NTPNodeSetting("blue", ST.BOOL),
-			NTPNodeSetting("green", ST.BOOL),
-			NTPNodeSetting("highlights_contrast", ST.FLOAT),
-			NTPNodeSetting("highlights_gain", ST.FLOAT),
-			NTPNodeSetting("highlights_gamma", ST.FLOAT),
-			NTPNodeSetting("highlights_lift", ST.FLOAT),
-			NTPNodeSetting("highlights_saturation", ST.FLOAT),
-			NTPNodeSetting("master_contrast", ST.FLOAT),
-			NTPNodeSetting("master_gain", ST.FLOAT),
-			NTPNodeSetting("master_gamma", ST.FLOAT),
-			NTPNodeSetting("master_lift", ST.FLOAT),
-			NTPNodeSetting("master_saturation", ST.FLOAT),
-			NTPNodeSetting("midtones_contrast", ST.FLOAT),
-			NTPNodeSetting("midtones_end", ST.FLOAT),
-			NTPNodeSetting("midtones_gain", ST.FLOAT),
-			NTPNodeSetting("midtones_gamma", ST.FLOAT),
-			NTPNodeSetting("midtones_lift", ST.FLOAT),
-			NTPNodeSetting("midtones_saturation", ST.FLOAT),
-			NTPNodeSetting("midtones_start", ST.FLOAT),
-			NTPNodeSetting("red", ST.BOOL),
-			NTPNodeSetting("shadows_contrast", ST.FLOAT),
-			NTPNodeSetting("shadows_gain", ST.FLOAT),
-			NTPNodeSetting("shadows_gamma", ST.FLOAT),
-			NTPNodeSetting("shadows_lift", ST.FLOAT),
-			NTPNodeSetting("shadows_saturation", ST.FLOAT),
+			NTPNodeSetting("blue", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("green", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("highlights_contrast", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("highlights_gain", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("highlights_gamma", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("highlights_lift", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("highlights_saturation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("master_contrast", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("master_gain", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("master_gamma", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("master_lift", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("master_saturation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_contrast", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_end", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_gain", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_gamma", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_lift", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_saturation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("midtones_start", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("red", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadows_contrast", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadows_gain", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadows_gamma", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadows_lift", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("shadows_saturation", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeColorMatte' : NodeInfo(
 		[
-			NTPNodeSetting("color_hue", ST.FLOAT),
-			NTPNodeSetting("color_saturation", ST.FLOAT),
-			NTPNodeSetting("color_value", ST.FLOAT),
+			NTPNodeSetting("color_hue", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("color_saturation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("color_value", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -226,11 +226,11 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("channel", ST.ENUM),
 			NTPNodeSetting("limit_channel", ST.ENUM),
 			NTPNodeSetting("limit_method", ST.ENUM),
-			NTPNodeSetting("ratio", ST.FLOAT),
-			NTPNodeSetting("unspill_blue", ST.FLOAT),
-			NTPNodeSetting("unspill_green", ST.FLOAT),
-			NTPNodeSetting("unspill_red", ST.FLOAT),
-			NTPNodeSetting("use_unspill", ST.BOOL),
+			NTPNodeSetting("ratio", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("unspill_blue", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("unspill_green", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("unspill_red", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_unspill", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -267,7 +267,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeComposite' : NodeInfo(
 		[
-			NTPNodeSetting("use_alpha", ST.BOOL),
+			NTPNodeSetting("use_alpha", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -280,21 +280,23 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'CompositorNodeCornerPin' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0)),
+		]
 	),
 
 	'CompositorNodeCrop' : NodeInfo(
 		[
-			NTPNodeSetting("max_x", ST.INT),
-			NTPNodeSetting("max_y", ST.INT),
-			NTPNodeSetting("min_x", ST.INT),
-			NTPNodeSetting("min_y", ST.INT),
-			NTPNodeSetting("rel_max_x", ST.FLOAT),
-			NTPNodeSetting("rel_max_y", ST.FLOAT),
-			NTPNodeSetting("rel_min_x", ST.FLOAT),
-			NTPNodeSetting("rel_min_y", ST.FLOAT),
-			NTPNodeSetting("relative", ST.BOOL),
-			NTPNodeSetting("use_crop_size", ST.BOOL),
+			NTPNodeSetting("max_x", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("max_y", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("min_x", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("min_y", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("rel_max_x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("rel_max_y", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("rel_min_x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("rel_min_y", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("relative", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_crop_size", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -350,14 +352,14 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeDBlur' : NodeInfo(
 		[
-			NTPNodeSetting("angle", ST.FLOAT),
-			NTPNodeSetting("center_x", ST.FLOAT),
-			NTPNodeSetting("center_y", ST.FLOAT),
-			NTPNodeSetting("distance", ST.FLOAT),
-			NTPNodeSetting("iterations", ST.INT),
-			NTPNodeSetting("spin", ST.FLOAT),
+			NTPNodeSetting("angle", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("center_x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("center_y", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("distance", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("spin", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_wrap", ST.BOOL, max_version_=(3, 5, 0)),
-			NTPNodeSetting("zoom", ST.FLOAT),
+			NTPNodeSetting("zoom", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -368,9 +370,9 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("bokeh", ST.ENUM),
 			NTPNodeSetting("f_stop", ST.FLOAT),
 			NTPNodeSetting("scene", ST.SCENE),
-			NTPNodeSetting("threshold", ST.FLOAT),
-			NTPNodeSetting("use_gamma_correction", ST.BOOL),
-			NTPNodeSetting("use_preview", ST.BOOL),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_gamma_correction", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_preview", ST.BOOL, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_zbuffer", ST.BOOL),
 			NTPNodeSetting("z_scale", ST.FLOAT),
 		]
@@ -380,42 +382,44 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("prefilter", ST.ENUM),
 			NTPNodeSetting("quality", ST.ENUM, min_version_=(4, 4, 0)),
-			NTPNodeSetting("use_hdr", ST.BOOL),
+			NTPNodeSetting("use_hdr", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeDespeckle' : NodeInfo(
 		[
-			NTPNodeSetting("threshold", ST.FLOAT),
-			NTPNodeSetting("threshold_neighbor", ST.FLOAT),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("threshold_neighbor", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeDiffMatte' : NodeInfo(
 		[
-			NTPNodeSetting("falloff", ST.FLOAT),
-			NTPNodeSetting("tolerance", ST.FLOAT),
+			NTPNodeSetting("falloff", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeDilateErode' : NodeInfo(
 		[
-			NTPNodeSetting("distance", ST.INT),
-			NTPNodeSetting("edge", ST.FLOAT),
+			NTPNodeSetting("distance", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("edge", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("falloff", ST.ENUM),
 			NTPNodeSetting("mode", ST.ENUM),
 		]
 	),
 
 	'CompositorNodeDisplace' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(5, 0, 0)),
+		]
 	),
 
 	'CompositorNodeDistanceMatte' : NodeInfo(
 		[
 			NTPNodeSetting("channel", ST.ENUM),
-			NTPNodeSetting("falloff", ST.FLOAT),
-			NTPNodeSetting("tolerance", ST.FLOAT),
+			NTPNodeSetting("falloff", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -429,13 +433,13 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeEllipseMask' : NodeInfo(
 		[
 			NTPNodeSetting("height", ST.FLOAT, max_version_=(4, 2, 0)),
-			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0)),
+			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("mask_type", ST.ENUM),
-			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0)),
-			NTPNodeSetting("rotation", ST.FLOAT),
+			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
+			NTPNodeSetting("rotation", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("width", ST.FLOAT, max_version_=(4, 2, 0)),
-			NTPNodeSetting("x", ST.FLOAT),
-			NTPNodeSetting("y", ST.FLOAT),
+			NTPNodeSetting("x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("y", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -451,7 +455,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeFlip' : NodeInfo(
 		[
-			NTPNodeSetting("axis", ST.ENUM),
+			NTPNodeSetting("axis", ST.ENUM, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -461,17 +465,17 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeGlare' : NodeInfo(
 		[
-			NTPNodeSetting("angle_offset", ST.FLOAT),
-			NTPNodeSetting("color_modulation", ST.FLOAT),
-			NTPNodeSetting("fade", ST.FLOAT),
+			NTPNodeSetting("angle_offset", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("color_modulation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("fade", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("glare_type", ST.ENUM),
-			NTPNodeSetting("iterations", ST.INT),
-			NTPNodeSetting("mix", ST.FLOAT),
+			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("mix", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("quality", ST.ENUM),
-			NTPNodeSetting("size", ST.INT),
-			NTPNodeSetting("streaks", ST.INT),
-			NTPNodeSetting("threshold", ST.FLOAT),
-			NTPNodeSetting("use_rotate_45", ST.BOOL),
+			NTPNodeSetting("size", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("streaks", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_rotate_45", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -493,8 +497,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeIDMask' : NodeInfo(
 		[
-			NTPNodeSetting("index", ST.INT),
-			NTPNodeSetting("use_antialiasing", ST.BOOL),
+			NTPNodeSetting("index", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_antialiasing", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -507,56 +511,66 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("layer", ST.ENUM),
 			NTPNodeSetting("use_auto_refresh", ST.BOOL),
 			NTPNodeSetting("use_cyclic", ST.BOOL),
-			NTPNodeSetting("use_straight_alpha_output", ST.BOOL),
+			NTPNodeSetting("use_straight_alpha_output", ST.BOOL, max_version_=(4, 5, 0)),
 			NTPNodeSetting("view", ST.ENUM),
 		]
 	),
 
+	'CompositorNodeImageCoordinates' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
+	'CompositorNodeImageInfo' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
 	'CompositorNodeInpaint' : NodeInfo(
 		[
-			NTPNodeSetting("distance", ST.INT),
+			NTPNodeSetting("distance", ST.INT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeInvert' : NodeInfo(
 		[
-			NTPNodeSetting("invert_alpha", ST.BOOL),
-			NTPNodeSetting("invert_rgb", ST.BOOL),
+			NTPNodeSetting("invert_alpha", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("invert_rgb", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeKeying' : NodeInfo(
 		[
-			NTPNodeSetting("blur_post", ST.INT),
-			NTPNodeSetting("blur_pre", ST.INT),
-			NTPNodeSetting("clip_black", ST.FLOAT),
-			NTPNodeSetting("clip_white", ST.FLOAT),
-			NTPNodeSetting("despill_balance", ST.FLOAT),
-			NTPNodeSetting("despill_factor", ST.FLOAT),
-			NTPNodeSetting("dilate_distance", ST.INT),
-			NTPNodeSetting("edge_kernel_radius", ST.INT),
-			NTPNodeSetting("edge_kernel_tolerance", ST.FLOAT),
-			NTPNodeSetting("feather_distance", ST.INT),
+			NTPNodeSetting("blur_post", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("blur_pre", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("clip_black", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("clip_white", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("despill_balance", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("despill_factor", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("dilate_distance", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("edge_kernel_radius", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("edge_kernel_tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("feather_distance", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("feather_falloff", ST.ENUM),
-			NTPNodeSetting("screen_balance", ST.FLOAT),
+			NTPNodeSetting("screen_balance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeKeyingScreen' : NodeInfo(
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
-			NTPNodeSetting("smoothness", ST.FLOAT, min_version_=(4, 1, 0)),
+			NTPNodeSetting("smoothness", ST.FLOAT, min_version_=(4, 1, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("tracking_object", ST.STRING),
 		]
 	),
 
 	'CompositorNodeKuwahara' : NodeInfo(
 		[
-			NTPNodeSetting("eccentricity", ST.FLOAT),
-			NTPNodeSetting("sharpness", ST.FLOAT),
+			NTPNodeSetting("eccentricity", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("sharpness", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("size", ST.INT, max_version_=(4, 1, 0)),
-			NTPNodeSetting("uniformity", ST.INT),
-			NTPNodeSetting("use_high_precision", ST.BOOL, min_version_=(4, 1, 0)),
+			NTPNodeSetting("uniformity", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_high_precision", ST.BOOL, min_version_=(4, 1, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("variation", ST.ENUM),
 		],
 		min_version_ = (4, 0, 0)
@@ -564,9 +578,10 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeLensdist' : NodeInfo(
 		[
-			NTPNodeSetting("use_fit", ST.BOOL),
-			NTPNodeSetting("use_jitter", ST.BOOL),
-			NTPNodeSetting("use_projector", ST.BOOL),
+			NTPNodeSetting("distortion_type", ST.ENUM, min_version_=(4, 5, 0)),
+			NTPNodeSetting("use_fit", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_jitter", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_projector", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -578,8 +593,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeLumaMatte' : NodeInfo(
 		[
-			NTPNodeSetting("limit_max", ST.FLOAT),
-			NTPNodeSetting("limit_min", ST.FLOAT),
+			NTPNodeSetting("limit_max", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("limit_min", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -591,7 +606,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeMapUV' : NodeInfo(
 		[
-			NTPNodeSetting("alpha", ST.INT),
+			NTPNodeSetting("alpha", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("filter_type", ST.ENUM, min_version_=(4, 1, 0)),
 		]
 	),
@@ -610,13 +625,13 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeMask' : NodeInfo(
 		[
 			NTPNodeSetting("mask", ST.MASK),
-			NTPNodeSetting("motion_blur_samples", ST.INT),
-			NTPNodeSetting("motion_blur_shutter", ST.FLOAT),
+			NTPNodeSetting("motion_blur_samples", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("motion_blur_shutter", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("size_source", ST.ENUM),
-			NTPNodeSetting("size_x", ST.INT),
-			NTPNodeSetting("size_y", ST.INT),
-			NTPNodeSetting("use_feather", ST.BOOL),
-			NTPNodeSetting("use_motion_blur", ST.BOOL),
+			NTPNodeSetting("size_x", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("size_y", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_feather", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_motion_blur", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -669,18 +684,18 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodePixelate' : NodeInfo(
 		[
-			NTPNodeSetting("pixel_size", ST.INT, min_version_=(4, 1, 0)),
+			NTPNodeSetting("pixel_size", ST.INT, min_version_=(4, 1, 0), max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodePlaneTrackDeform' : NodeInfo(
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
-			NTPNodeSetting("motion_blur_samples", ST.INT),
-			NTPNodeSetting("motion_blur_shutter", ST.FLOAT),
+			NTPNodeSetting("motion_blur_samples", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("motion_blur_shutter", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("plane_track_name", ST.STRING),
 			NTPNodeSetting("tracking_object", ST.STRING),
-			NTPNodeSetting("use_motion_blur", ST.BOOL),
+			NTPNodeSetting("use_motion_blur", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -709,6 +724,14 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'CompositorNodeRelativeToPixel' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("reference_dimension", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'CompositorNodeRotate' : NodeInfo(
 		[
 			NTPNodeSetting("filter_type", ST.ENUM),
@@ -718,8 +741,9 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeScale' : NodeInfo(
 		[
 			NTPNodeSetting("frame_method", ST.ENUM),
-			NTPNodeSetting("offset_x", ST.FLOAT),
-			NTPNodeSetting("offset_y", ST.FLOAT),
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0)),
+			NTPNodeSetting("offset_x", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("offset_y", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("space", ST.ENUM),
 		]
 	),
@@ -769,7 +793,7 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeSplit' : NodeInfo(
 		[
 			NTPNodeSetting("axis", ST.ENUM),
-			NTPNodeSetting("factor", ST.INT),
+			NTPNodeSetting("factor", ST.INT, max_version_=(4, 5, 0)),
 		],
 		min_version_ = (4, 1, 0)
 	),
@@ -786,20 +810,20 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
 			NTPNodeSetting("filter_type", ST.ENUM),
-			NTPNodeSetting("invert", ST.BOOL),
+			NTPNodeSetting("invert", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeSunBeams' : NodeInfo(
 		[
-			NTPNodeSetting("ray_length", ST.FLOAT),
-			NTPNodeSetting("source", ST.VEC2),
+			NTPNodeSetting("ray_length", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("source", ST.VEC2, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeSwitch' : NodeInfo(
 		[
-			NTPNodeSetting("check", ST.BOOL),
+			NTPNodeSetting("check", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -817,8 +841,8 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeTime' : NodeInfo(
 		[
 			NTPNodeSetting("curve", ST.CURVE_MAPPING),
-			NTPNodeSetting("frame_end", ST.INT),
-			NTPNodeSetting("frame_start", ST.INT),
+			NTPNodeSetting("frame_end", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("frame_start", ST.INT, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -854,7 +878,7 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeTranslate' : NodeInfo(
 		[
 			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 2, 0)),
-			NTPNodeSetting("use_relative", ST.BOOL),
+			NTPNodeSetting("use_relative", ST.BOOL, max_version_=(4, 5, 0)),
 			NTPNodeSetting("wrap_axis", ST.ENUM),
 		]
 	),
@@ -871,11 +895,11 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeVecBlur' : NodeInfo(
 		[
-			NTPNodeSetting("factor", ST.FLOAT),
-			NTPNodeSetting("samples", ST.INT),
-			NTPNodeSetting("speed_max", ST.INT),
-			NTPNodeSetting("speed_min", ST.INT),
-			NTPNodeSetting("use_curved", ST.BOOL),
+			NTPNodeSetting("factor", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("samples", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("speed_max", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("speed_min", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_curved", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -885,14 +909,14 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("center_y", ST.FLOAT, max_version_=(4, 2, 0)),
 			NTPNodeSetting("tile_order", ST.ENUM, max_version_=(4, 2, 0)),
 			NTPNodeSetting("ui_shortcut", ST.INT, min_version_=(4, 4, 0)),
-			NTPNodeSetting("use_alpha", ST.BOOL),
+			NTPNodeSetting("use_alpha", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
 	'CompositorNodeZcombine' : NodeInfo(
 		[
-			NTPNodeSetting("use_alpha", ST.BOOL),
-			NTPNodeSetting("use_antialias_z", ST.BOOL),
+			NTPNodeSetting("use_alpha", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_antialias_z", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -922,6 +946,13 @@ node_settings : dict[str, NodeInfo] = {
 	'FunctionNodeAxisAngleToRotation' : NodeInfo(
 		[],
 		min_version_ = (4, 0, 0)
+	),
+
+	'FunctionNodeBitMath' : NodeInfo(
+		[
+			NTPNodeSetting("operation", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'FunctionNodeBooleanMath' : NodeInfo(
@@ -977,6 +1008,13 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("rounding_mode", ST.ENUM),
 		]
+	),
+
+	'FunctionNodeFormatString' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'FunctionNodeHashValue' : NodeInfo(
@@ -1048,6 +1086,13 @@ node_settings : dict[str, NodeInfo] = {
 	'FunctionNodeLegacyRandomFloat' : NodeInfo(
 		[],
 		max_version_ = (3, 2, 0)
+	),
+
+	'FunctionNodeMatchString' : NodeInfo(
+		[
+			NTPNodeSetting("operation", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'FunctionNodeMatrixDeterminant' : NodeInfo(
@@ -1216,6 +1261,11 @@ node_settings : dict[str, NodeInfo] = {
 		[]
 	),
 
+	'GeometryNodeCameraInfo' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeCaptureAttribute' : NodeInfo(
 		[
 			NTPNodeSetting("active_index", ST.INT, min_version_=(4, 2, 0)),
@@ -1225,10 +1275,30 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'GeometryNodeClosureInput' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeClosureOutput' : NodeInfo(
+		[
+			NTPNodeSetting("active_input_index", ST.INT),
+			NTPNodeSetting("active_output_index", ST.INT),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeCollectionInfo' : NodeInfo(
 		[
 			NTPNodeSetting("transform_space", ST.ENUM),
 		]
+	),
+
+	'GeometryNodeCombineBundle' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'GeometryNodeConvexHull' : NodeInfo(
@@ -1422,6 +1492,14 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 5, 0)
 	),
 
+	'GeometryNodeEvaluateClosure' : NodeInfo(
+		[
+			NTPNodeSetting("active_input_index", ST.INT),
+			NTPNodeSetting("active_output_index", ST.INT),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeExtrudeMesh' : NodeInfo(
 		[
 			NTPNodeSetting("mode", ST.ENUM),
@@ -1442,12 +1520,36 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 1, 0)
 	),
 
+	'GeometryNodeFieldAverage' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("domain", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeFieldMinAndMax' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("domain", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeFieldOnDomain' : NodeInfo(
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
 			NTPNodeSetting("domain", ST.ENUM),
 		],
 		min_version_ = (3, 3, 0)
+	),
+
+	'GeometryNodeFieldVariance' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("domain", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'GeometryNodeFillCurve' : NodeInfo(
@@ -1533,6 +1635,13 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (4, 3, 0)
 	),
 
+	'GeometryNodeGridInfo' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeGridToMesh' : NodeInfo(
 		[],
 		min_version_ = (4, 2, 0)
@@ -1556,6 +1665,11 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'GeometryNodeImportCSV' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeImportOBJ' : NodeInfo(
 		[],
 		min_version_ = (4, 3, 0)
@@ -1569,6 +1683,16 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeImportSTL' : NodeInfo(
 		[],
 		min_version_ = (4, 3, 0)
+	),
+
+	'GeometryNodeImportText' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeImportVDB' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
 	),
 
 	'GeometryNodeIndexOfNearest' : NodeInfo(
@@ -1622,6 +1746,11 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeInputIndex' : NodeInfo(
 		[]
+	),
+
+	'GeometryNodeInputInstanceBounds' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
 	),
 
 	'GeometryNodeInputInstanceRotation' : NodeInfo(
@@ -2162,7 +2291,9 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'GeometryNodeMeshToCurve' : NodeInfo(
-		[]
+		[
+			NTPNodeSetting("mode", ST.ENUM, min_version_=(4, 5, 0)),
+		]
 	),
 
 	'GeometryNodeMeshToDensityGrid' : NodeInfo(
@@ -2411,6 +2542,13 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 4, 0)
 	),
 
+	'GeometryNodeSeparateBundle' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeSeparateComponents' : NodeInfo(
 		[]
 	),
@@ -2447,6 +2585,25 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (4, 3, 0)
 	),
 
+	'GeometryNodeSetGreasePencilColor' : NodeInfo(
+		[
+			NTPNodeSetting("mode", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeSetGreasePencilDepth' : NodeInfo(
+		[
+			NTPNodeSetting("depth_order", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeSetGreasePencilSoftness' : NodeInfo(
+		[],
+		min_version_ = (4, 5, 0)
+	),
+
 	'GeometryNodeSetID' : NodeInfo(
 		[]
 	),
@@ -2462,6 +2619,14 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeSetMaterialIndex' : NodeInfo(
 		[]
+	),
+
+	'GeometryNodeSetMeshNormal' : NodeInfo(
+		[
+			NTPNodeSetting("domain", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'GeometryNodeSetPointRadius' : NodeInfo(
@@ -2640,7 +2805,9 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'GeometryNodeUVPackIslands' : NodeInfo(
-		[],
+		[
+			NTPNodeSetting("shape_method", ST.ENUM, min_version_=(5, 0, 0)),
+		],
 		min_version_ = (3, 3, 0)
 	),
 
@@ -2660,6 +2827,7 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
 			NTPNodeSetting("domain", ST.ENUM, min_version_=(3, 4, 0)),
+			NTPNodeSetting("ui_shortcut", ST.INT, min_version_=(4, 5, 0)),
 		]
 	),
 
@@ -3223,16 +3391,16 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("air_density", ST.FLOAT),
 			NTPNodeSetting("altitude", ST.FLOAT),
 			NTPNodeSetting("dust_density", ST.FLOAT),
-			NTPNodeSetting("ground_albedo", ST.FLOAT),
+			NTPNodeSetting("ground_albedo", ST.FLOAT, max_version_=(5, 0, 0)),
 			NTPNodeSetting("ozone_density", ST.FLOAT),
 			NTPNodeSetting("sky_type", ST.ENUM),
-			NTPNodeSetting("sun_direction", ST.VEC3),
+			NTPNodeSetting("sun_direction", ST.VEC3, max_version_=(5, 0, 0)),
 			NTPNodeSetting("sun_disc", ST.BOOL),
 			NTPNodeSetting("sun_elevation", ST.FLOAT),
 			NTPNodeSetting("sun_intensity", ST.FLOAT),
 			NTPNodeSetting("sun_rotation", ST.FLOAT),
 			NTPNodeSetting("sun_size", ST.FLOAT),
-			NTPNodeSetting("turbidity", ST.FLOAT),
+			NTPNodeSetting("turbidity", ST.FLOAT, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -3324,6 +3492,13 @@ node_settings : dict[str, NodeInfo] = {
 
 	'ShaderNodeVolumeAbsorption' : NodeInfo(
 		[]
+	),
+
+	'ShaderNodeVolumeCoefficients' : NodeInfo(
+		[
+			NTPNodeSetting("phase", ST.ENUM),
+		],
+		min_version_ = (4, 5, 0)
 	),
 
 	'ShaderNodeVolumeInfo' : NodeInfo(

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -26,6 +26,7 @@ class ST(Enum):
 	FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
 	FOREACH_GEO_ELEMENT_INPUT_ITEMS = auto()
 	FOREACH_GEO_ELEMENT_MAIN_ITEMS = auto()
+	FORMAT_STRING_ITEMS = auto()
 	INDEX_SWITCH_ITEMS = auto()
 	MENU_SWITCH_ITEMS = auto()
 	NODE_TREE = auto()
@@ -410,9 +411,7 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'CompositorNodeDisplace' : NodeInfo(
-		[
-			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(5, 0, 0)),
-		]
+		[]
 	),
 
 	'CompositorNodeDistanceMatte' : NodeInfo(
@@ -465,17 +464,17 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeGlare' : NodeInfo(
 		[
-			NTPNodeSetting("angle_offset", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("color_modulation", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("fade", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("angle_offset", ST.FLOAT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("color_modulation", ST.FLOAT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("fade", ST.FLOAT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("glare_type", ST.ENUM),
-			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("mix", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("mix", ST.FLOAT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("quality", ST.ENUM),
-			NTPNodeSetting("size", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("streaks", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("use_rotate_45", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("size", ST.INT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("streaks", ST.INT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 4, 0)),
+			NTPNodeSetting("use_rotate_45", ST.BOOL, max_version_=(4, 4, 0)),
 		]
 	),
 
@@ -848,13 +847,13 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeTonemap' : NodeInfo(
 		[
-			NTPNodeSetting("adaptation", ST.FLOAT),
-			NTPNodeSetting("contrast", ST.FLOAT),
-			NTPNodeSetting("correction", ST.FLOAT),
-			NTPNodeSetting("gamma", ST.FLOAT),
-			NTPNodeSetting("intensity", ST.FLOAT),
-			NTPNodeSetting("key", ST.FLOAT),
-			NTPNodeSetting("offset", ST.FLOAT),
+			NTPNodeSetting("adaptation", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("contrast", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("correction", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("gamma", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("intensity", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("key", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("offset", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("tonemap_type", ST.ENUM),
 		]
 	),
@@ -1013,6 +1012,7 @@ node_settings : dict[str, NodeInfo] = {
 	'FunctionNodeFormatString' : NodeInfo(
 		[
 			NTPNodeSetting("active_index", ST.INT),
+			NTPNodeSetting("format_items", ST.FORMAT_STRING_ITEMS),
 		],
 		min_version_ = (4, 5, 0)
 	),
@@ -2805,9 +2805,7 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'GeometryNodeUVPackIslands' : NodeInfo(
-		[
-			NTPNodeSetting("shape_method", ST.ENUM, min_version_=(5, 0, 0)),
-		],
+		[],
 		min_version_ = (3, 3, 0)
 	),
 
@@ -3391,16 +3389,16 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("air_density", ST.FLOAT),
 			NTPNodeSetting("altitude", ST.FLOAT),
 			NTPNodeSetting("dust_density", ST.FLOAT),
-			NTPNodeSetting("ground_albedo", ST.FLOAT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("ground_albedo", ST.FLOAT),
 			NTPNodeSetting("ozone_density", ST.FLOAT),
 			NTPNodeSetting("sky_type", ST.ENUM),
-			NTPNodeSetting("sun_direction", ST.VEC3, max_version_=(5, 0, 0)),
+			NTPNodeSetting("sun_direction", ST.VEC3),
 			NTPNodeSetting("sun_disc", ST.BOOL),
 			NTPNodeSetting("sun_elevation", ST.FLOAT),
 			NTPNodeSetting("sun_intensity", ST.FLOAT),
 			NTPNodeSetting("sun_rotation", ST.FLOAT),
 			NTPNodeSetting("sun_size", ST.FLOAT),
-			NTPNodeSetting("turbidity", ST.FLOAT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("turbidity", ST.FLOAT),
 		]
 	),
 

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -454,6 +454,8 @@ class NTP_Operator(Operator):
                 self._foreach_geo_element_input_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS:
                 self._foreach_geo_element_main_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.FORMAT_STRING_ITEMS:
+                self._format_string_items(attr, f"{node_var}.{attr_name}")
 
     if bpy.app.version < (4, 0, 0):
         def _set_group_socket_defaults(self, socket_interface: NodeSocketInterface,
@@ -1348,6 +1350,16 @@ class NTP_Operator(Operator):
                 socket_type = enum_to_py_str(item.socket_type)
                 name_str = str_to_py_str(item.name)
                 self._write(f"{main_items_str}.new({socket_type}, {name_str})")
+
+    if bpy.app.version >= (4, 5, 0):
+        def _format_string_items(self,
+                          format_items : bpy.types.NodeFunctionFormatStringItems,
+                          format_items_str: str) -> None:
+            self._write(f"{format_items_str}.clear()")
+            for i, item in enumerate(format_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write(f"{format_items_str}.new({socket_type}, {name_str})")
 
 
     def _set_parents(self, node_tree: NodeTree) -> None:

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -831,14 +831,19 @@ class NTP_Operator(Operator):
 
                 # vector types
                 elif "Vector" in input.bl_idname:
-                    default_val = vec3_to_py_str(input.default_value)
+                    if "2D" in input.bl_idname:
+                        default_val = vec2_to_py_str(input.default_value)
+                    elif "4D" in input.bl_idname:
+                        default_val = vec4_to_py_str(input.default_value)
+                    else:
+                        default_val = vec3_to_py_str(input.default_value)
 
                 # rotation types
                 elif input.bl_idname == 'NodeSocketRotation':
                     default_val = vec3_to_py_str(input.default_value)
 
                 # strings
-                elif input.bl_idname == 'NodeSocketString':
+                elif input.bl_idname in {'NodeSocketString', 'NodeSocketStringFilePath'}:
                     default_val = str_to_py_str(input.default_value)
 
                 #menu

--- a/tools/node_settings_generator/parse_nodes.py
+++ b/tools/node_settings_generator/parse_nodes.py
@@ -181,9 +181,11 @@ def process_bpy_version(version: Version) -> None:
 
 def generate_versions(max_version_inc: Version) -> list[Version]:
     BLENDER_3_MAX_VERSION = 6
+    BLENDER_4_MAX_VERSION = 5
 
     versions = [Version(3, i) for i in range(0, BLENDER_3_MAX_VERSION + 1)]
-    versions += [Version(4, i) for i in range(0, max_version_inc[1] + 1)]
+    versions += [Version(4, i) for i in range(0, BLENDER_4_MAX_VERSION + 1)]
+    versions += [Version(5, i) for i in range(0, max_version_inc.minor_ + 1)]
     
     #lazy max version check
     for version in versions[::-1]:

--- a/tools/node_settings_generator/parse_nodes.py
+++ b/tools/node_settings_generator/parse_nodes.py
@@ -37,18 +37,40 @@ nodes_dict : dict[str, NodeInfo] = {}
 types_dict : dict[str, set[str]] = {}
 log_file = None
 
-NTP_MIN_VERSION = (3, 0)
+BLENDER_3_MAX_VERSION = 6
+BLENDER_4_MAX_VERSION = 5
+BLENDER_5_MAX_VERSION = 0
+
+NTP_MIN_VERSION = Version(3, 0)
+
+BLENDER_VERSIONS  = [Version(3, i) for i in range(0, BLENDER_3_MAX_VERSION + 1)]
+BLENDER_VERSIONS += [Version(4, i) for i in range(0, BLENDER_4_MAX_VERSION + 1)]
+BLENDER_VERSIONS += [Version(5, i) for i in range(0, BLENDER_5_MAX_VERSION + 1)]
+
+def log(message: str):
+    if log_file is None:
+        raise RuntimeError("Log file was null!")
+    with log_mutex:
+        log_file.write(message)
 
 def process_attr(attr, section, node: str, version: Version) -> None:
+    # Get name
     name_section = attr.find(["code", "span"], class_="sig-name descname")
-    
     if not name_section:
         raise ValueError(f"{version.tuple_str()} {node}: Couldn't find name section in\n\t{section}")
     name = name_section.text
+
+    # Check for deprecation
+    if "Deprecated" in str(attr):
+        log(f"WARNING: {version.tuple_str()} Attribute {node}.{name} "
+            f"was marked deprecated, returning\n")
+        return
     
+    # Get type
     type_section = attr.find("dd", class_="field-odd")
     if not type_section:
-        raise ValueError(f"{version.tuple_str()} {node}.{name}: Couldn't find type section in\n\t{section}")
+        raise ValueError(f"{version.tuple_str()} {node}.{name}: "
+                         f"Couldn't find type section in\n\t{section}")
     type_text = type_section.text
 
     with mutex:
@@ -61,8 +83,8 @@ def process_attr(attr, section, node: str, version: Version) -> None:
     ntp_type = types_utils.get_NTP_type(type_text)
     if ntp_type is None:
         # Read-only attribute, don't add to attribute list
-        with log_mutex:
-            log_file.write(f"WARNING: {version.tuple_str()} {node}.{name}'s type is being ignored:\n\t{type_text.strip()}\n")
+        log(f"WARNING: {version.tuple_str()} {node}.{name}'s "
+            f"type is being ignored:\n\t{type_text.strip()}\n")
         return
 
     ntp_setting = NTPNodeSetting(name, ntp_type)
@@ -114,7 +136,7 @@ def download_file(filepath: str, version: Version, local_path: str) -> bool:
 
 
 def get_subclasses(current: str, parent: str, root_path: str, 
-                   version: Version) -> list[str]:
+                   version: Version) -> None:
     relative_path = f"bpy.types.{current}.html"
     current_path = os.path.join(root_path, relative_path)
 
@@ -132,12 +154,14 @@ def get_subclasses(current: str, parent: str, root_path: str,
     main_id = f"{current.lower()}-{parent.lower()}"
     sections = soup.find_all(id=main_id)
     if not sections:
-        raise ValueError(f"{version.tuple_str()} {current}: Couldn't find main section with id {main_id}")
+        raise ValueError(f"{version.tuple_str()} {current}: "
+                         f"Couldn't find main section with id {main_id}")
 
     section = sections[0]
     paragraphs = section.find_all("p")
     if len(paragraphs) < 2:
-        raise ValueError(f"{version.tuple_str()} {current}: Couldn't find subclass section")
+        raise ValueError(f"{version.tuple_str()} {current}: "
+                         f"Couldn't find subclass section")
 
     subclasses_paragraph = paragraphs[1]
     if not subclasses_paragraph.text.strip().startswith("subclasses —"):
@@ -147,7 +171,8 @@ def get_subclasses(current: str, parent: str, root_path: str,
 
     subclass_anchors = subclasses_paragraph.find_all("a")
     if not subclass_anchors:
-        raise ValueError(f"{version.tuple_str()} {current} No anchors in subclasses paragraph")
+        raise ValueError(f"{version.tuple_str()} {current} "
+                         f"No anchors in subclasses paragraph")
 
     subclass_types = [anchor.get("title") for anchor in subclass_anchors]
     threads: list[Thread] = []
@@ -156,13 +181,15 @@ def get_subclasses(current: str, parent: str, root_path: str,
             raise ValueError(f"{version.tuple_str()} {current} Type was invalid")
         is_matching = re.match(r"bpy\.types\.(.*)", type)
         if not is_matching:
-            raise ValueError(f"{version.tuple_str()} {current}: Type {type} was not of the form \"bpy.types.x\"")
+            raise ValueError(f"{version.tuple_str()} {current}: "
+                             f"Type {type} was not of the form \"bpy.types.x\"")
         pure_type = is_matching.group(1)
         if (pure_type == "TextureNode"):
             # unsupported
             continue
 
-        thread = Thread(target=get_subclasses, args=(pure_type, current, root_path, version))
+        thread = Thread(target=get_subclasses, 
+                        args=(pure_type, current, root_path, version))
         threads.append(thread)
         thread.start()
 
@@ -180,16 +207,13 @@ def process_bpy_version(version: Version) -> None:
     get_subclasses(current, parent, root_path, version)
 
 def generate_versions(max_version_inc: Version) -> list[Version]:
-    BLENDER_3_MAX_VERSION = 6
-    BLENDER_4_MAX_VERSION = 5
+    versions = BLENDER_VERSIONS.copy()
 
-    versions = [Version(3, i) for i in range(0, BLENDER_3_MAX_VERSION + 1)]
-    versions += [Version(4, i) for i in range(0, BLENDER_4_MAX_VERSION + 1)]
-    versions += [Version(5, i) for i in range(0, max_version_inc.minor_ + 1)]
-    
-    #lazy max version check
+    # lazy version bounds check
     for version in versions[::-1]:
         if version > max_version_inc:
+            versions.remove(version)
+        if version < NTP_MIN_VERSION:
             versions.remove(version)
 
     return versions
@@ -197,7 +221,7 @@ def generate_versions(max_version_inc: Version) -> list[Version]:
 def subminor(version: Version) -> tuple:
     return (version[0], version[1], 0)
 
-def get_min_version(versions: list[Version]) -> Version:
+def get_min_version(versions: list[Version]) -> Version | None:
     min_version = min(versions)
 
     if min_version != NTP_MIN_VERSION:
@@ -206,7 +230,7 @@ def get_min_version(versions: list[Version]) -> Version:
         return None
 
 def get_max_version(versions: list[Version], blender_versions: list[Version]
-                   ) -> Version:
+                   ) -> Version | None:
     max_v_inclusive = max(versions)
     max_v_inclusive_index = blender_versions.index(max_v_inclusive)
     max_v_exclusive = blender_versions[max_v_inclusive_index + 1]
@@ -246,7 +270,8 @@ def write_node_info_class(file: TextIOWrapper):
     file.write("\n")
 
 def write_ntp_node_settings(node_info: NodeInfo, file: TextIOWrapper,
-                            node_min_v: Version, node_max_v: Version):
+                            node_min_v: Version | None, 
+                            node_max_v: Version | None) -> None:
     attr_dict = node_info.attributes_
     file.write("\n\t\t[")
     attrs_exist = len(attr_dict.items()) > 0
@@ -286,6 +311,14 @@ def write_node(name: str, node_info: NodeInfo, file: TextIOWrapper):
 
     file.write("\n\t),\n\n")
 
+def get_max_version_exc(max_version_inc : Version) -> Version:
+    idx = BLENDER_VERSIONS.index(max_version_inc)
+    exc_idx = idx + 1
+    if exc_idx < len(BLENDER_VERSIONS):
+        return BLENDER_VERSIONS[exc_idx]
+    else:
+        return Version(max_version_inc.major_, max_version_inc.minor_ + 1)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('max_major_version', type=int, 
@@ -312,7 +345,8 @@ if __name__ == "__main__":
     for version in versions:
         process_bpy_version(version)
 
-    NTP_MAX_VERSION_EXC = (NTP_MAX_VERSION_INC[0], NTP_MAX_VERSION_INC[1] + 1)
+    NTP_MAX_VERSION_EXC = get_max_version_exc(NTP_MAX_VERSION_INC)
+
     versions.append(NTP_MAX_VERSION_EXC)
 
     sorted_nodes = dict(sorted(nodes_dict.items()))
@@ -340,8 +374,8 @@ if __name__ == "__main__":
         print("Successfully finished")
 
     sorted_types = dict(sorted(types_dict.items()))
-    log_file.write("\nTypes encountered:\n")
+    log("\nTypes encountered:\n")
     for key, value in types_dict.items():
-        log_file.write(f"{key}\n")
+        log(f"{key}\n")
         for string in value:
-            log_file.write(f"\t{string}\n")
+            log(f"\t{string}\n")

--- a/tools/node_settings_generator/types_utils.py
+++ b/tools/node_settings_generator/types_utils.py
@@ -28,6 +28,7 @@ class ST(Enum):
     FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
     FOREACH_GEO_ELEMENT_INPUT_ITEMS      = auto()
     FOREACH_GEO_ELEMENT_MAIN_ITEMS       = auto()
+    FORMAT_STRING_ITEMS                  = auto()
     INDEX_SWITCH_ITEMS                   = auto()
     MENU_SWITCH_ITEMS                    = auto()
     NODE_TREE                            = auto()
@@ -66,6 +67,7 @@ READ_ONLY_TYPES : set[ST] = {
     ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS,
     ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS,
     ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS,
+    ST.FORMAT_STRING_ITEMS,
     ST.IMAGE_FORMAT_SETTINGS,
     ST.IMAGE_USER,
     ST.INDEX_SWITCH_ITEMS,
@@ -75,8 +77,8 @@ READ_ONLY_TYPES : set[ST] = {
     ST.SIM_OUTPUT_ITEMS,
 } 
 
-doc_to_NTP_type_dict : dict[str, ST] = {
-    "" : "",
+doc_to_NTP_type_dict : dict[str, ST | None] = {
+    "" : None,
     "bpy_prop_collection of CryptomatteEntry": ST.CRYPTOMATTE_ENTRIES,
     "boolean" : ST.BOOL,
     "Collection" : ST.COLLECTION,
@@ -106,6 +108,7 @@ doc_to_NTP_type_dict : dict[str, ST] = {
                    # output nodes exist. Handled separately from NTP attr system
     "NodeEnumDefinition" : ST.ENUM_DEFINITION,
     "NodeEnumItem" : ST.ENUM_ITEM,
+    "NodeFunctionFormatStringItems" : ST.FORMAT_STRING_ITEMS,
     "NodeGeometryBakeItems" : ST.BAKE_ITEMS,
     "NodeGeometryCaptureAttributeItems" : ST.CAPTURE_ATTRIBUTE_ITEMS,
     "NodeGeometryForeachGeometryElementGenerationItems": ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS,
@@ -129,7 +132,7 @@ doc_to_NTP_type_dict : dict[str, ST] = {
     "VectorFont" : ST.FONT
 }
 
-def get_NTP_type(type_str: str) -> str:
+def get_NTP_type(type_str: str) -> ST | None:
     """
     Time complexity isn't great, might be able to optimize with 
     a trie or similar data structure


### PR DESCRIPTION
# Issues
* #158 

# Features
## NodeToPython
* Support new nodes and settings
* Deprecated many compositor node settings that were converted to sockets
* Support new socket types
* Handle **Format String** items
* Support toggle panels
* Support new tree socket settings, including
    * `layer_selection_field`
    * `is_inspect_output` (4.2+)
    * `default_input` (4.5+)
    * `is_panel_toggle` (4.5+)
    * `menu_expanded` (4.5+)
    * `structure_type` (4.5+)
* Color balance node settings are no longer overridden starting with Blender 4.5

## NodeSettingsGenerator
* Script checks for setting deprecation in the attribute description.
    * Settings that are marked deprecated in a version will not be output for that Blender version, as they are typically either unneeded or set via another means in that Blender version (usually sockets)
* Added `ST.FORMAT_STRING_ITEMS` 
* Script now recognizes Blender 4.5 as the last in the 4.x series
* Added an `NTP_MIN_VERSION` global to make it easier skip Blender versions.
    *  Should do #143 for future improvements
* Logging is now thread-safe