### PR TITLE
Improve format

### DIFF
--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -242,7 +242,7 @@ class NTPCompositorOperator(NTP_Operator):
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy, mathutils\n\n")
+                self._file.write("import bpy\nimport mathutils\n\n\n")
 
         if self.is_scene:
             if self._mode == 'ADDON':

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -55,6 +55,7 @@ class NTPCompositorOperator(NTP_Operator):
         self._write(f"{SCENE}.name = {END_NAME}", indent_level)
         self._write(f"{SCENE}.use_fake_user = True", indent_level)
         self._write(f"bpy.context.window.scene = {SCENE}", indent_level)
+        self._write("", 0)
 
     def _initialize_compositor_node_tree(self, ntp_nt, nt_name):
         #initialize node group
@@ -63,6 +64,7 @@ class NTPCompositorOperator(NTP_Operator):
 
         if ntp_nt.node_tree == self._base_node_tree and self.is_scene:
             self._write(f"{ntp_nt.var} = {SCENE}.node_tree")
+            self._write("", 0)
             self._write(f"# Start with a clean node tree")
             self._write(f"for {NODE} in {ntp_nt.var}.nodes:")
             self._write(f"{ntp_nt.var}.nodes.remove({NODE})", self._inner_indent_level + 1)
@@ -187,7 +189,7 @@ class NTPCompositorOperator(NTP_Operator):
             self._tree_interface_settings(ntp_nt)
 
         #initialize nodes
-        self._write(f"# Initialize {nt_var} nodes")
+        self._write(f"# Initialize {nt_var} nodes\n")
 
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
@@ -201,6 +203,8 @@ class NTPCompositorOperator(NTP_Operator):
         self._init_links(node_tree)
         
         self._write(f"return {nt_var}\n")
+        if self._mode == 'SCRIPT':
+            self._write("", 0)
 
         #create node group
         self._write(f"{nt_var} = {nt_var}_node_group()\n", self._outer_indent_level)
@@ -249,6 +253,7 @@ class NTPCompositorOperator(NTP_Operator):
                 self._create_scene(2)
             elif self._mode == 'SCRIPT':
                 self._create_scene(0)
+                self._write("", 0)
 
         node_trees_to_process = self._topological_sort(self._base_node_tree)
 

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -39,12 +39,12 @@ class NTPCompositorOperator(NTP_Operator):
         self._write(f"{BASE_NAME} = {str_to_py_str(self.compositor_name)}",
                     indent_level)
         self._write(f"{END_NAME} = {BASE_NAME}", indent_level)
-        self._write(f"if bpy.data.scenes.get({END_NAME}) != None:", indent_level)
+        self._write(f"if bpy.data.scenes.get({END_NAME}) is not None:", indent_level)
 
         self._write(f"{INDEX} = 1", indent_level + 1)
         self._write(f"{END_NAME} = {BASE_NAME} + f\".{{i:03d}}\"", 
                     indent_level + 1)
-        self._write(f"while bpy.data.scenes.get({END_NAME}) != None:",
+        self._write(f"while bpy.data.scenes.get({END_NAME}) is not None:",
                     indent_level + 1)
         
         self._write(f"{END_NAME} = {BASE_NAME} + f\".{{{INDEX}:03d}}\"", 

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -58,8 +58,8 @@ class NTPCompositorOperator(NTP_Operator):
 
     def _initialize_compositor_node_tree(self, ntp_nt, nt_name):
         #initialize node group
-        self._write(f"#initialize {nt_name} node group", self._outer_indent_level)
         self._write(f"def {ntp_nt.var}_node_group():", self._outer_indent_level)
+        self._write(f'"""Initialize {nt_name} node group"""')
 
         if ntp_nt.node_tree == self._base_node_tree and self.is_scene:
             self._write(f"{ntp_nt.var} = {SCENE}.node_tree")

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -63,7 +63,7 @@ class NTPCompositorOperator(NTP_Operator):
 
         if ntp_nt.node_tree == self._base_node_tree and self.is_scene:
             self._write(f"{ntp_nt.var} = {SCENE}.node_tree")
-            self._write(f"#start with a clean node tree")
+            self._write(f"# Start with a clean node tree")
             self._write(f"for {NODE} in {ntp_nt.var}.nodes:")
             self._write(f"{ntp_nt.var}.nodes.remove({NODE})", self._inner_indent_level + 1)
         else:
@@ -187,7 +187,7 @@ class NTPCompositorOperator(NTP_Operator):
             self._tree_interface_settings(ntp_nt)
 
         #initialize nodes
-        self._write(f"#initialize {nt_var} nodes")
+        self._write(f"# Initialize {nt_var} nodes")
 
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -71,7 +71,7 @@ class NTPGeoNodesOperator(NTP_Operator):
                 zone_input_var = self._node_vars[zone_input]
                 zone_output_var = self._node_vars[zone_output]
 
-                self._write(f"#Process zone input {zone_input.name}")
+                self._write(f"# Process zone input {zone_input.name}")
                 self._write(f"{zone_input_var}.pair_with_output"
                             f"({zone_output_var})")
 
@@ -132,7 +132,7 @@ class NTPGeoNodesOperator(NTP_Operator):
             self._tree_interface_settings(ntp_nt)
 
         #initialize nodes
-        self._write(f"#initialize {nt_var} nodes")
+        self._write(f"# Initialize {nt_var} nodes\n")
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
 

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -116,8 +116,8 @@ class NTPGeoNodesOperator(NTP_Operator):
         self._node_tree_vars[node_tree] = nt_var
 
         #initialize node group
-        self._write(f"#initialize {nt_var} node group", self._outer_indent_level)
         self._write(f"def {nt_var}_node_group():", self._outer_indent_level)
+        self._write(f'"""Initialize {nt_var} node group"""')
         self._write(f"{nt_var} = bpy.data.node_groups.new("
                     f"type = \'GeometryNodeTree\', "
                     f"name = {str_to_py_str(node_tree.name)})\n")

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -191,7 +191,7 @@ class NTPGeoNodesOperator(NTP_Operator):
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy, mathutils\n\n")
+                self._file.write("import bpy\nimport mathutils\n\n\n")
 
 
         node_trees_to_process = self._topological_sort(nt)

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -78,7 +78,9 @@ class NTPGeoNodesOperator(NTP_Operator):
                 #must set defaults after paired with output
                 self._set_socket_defaults(zone_input)
                 self._set_socket_defaults(zone_output)
-            self._write("", 0)
+
+            if zone_inputs:
+                self._write("", 0)
 
     if bpy.app.version >= (4, 0, 0):
         def _set_geo_tree_properties(self, node_tree: GeometryNodeTree) -> None:
@@ -119,8 +121,8 @@ class NTPGeoNodesOperator(NTP_Operator):
         self._write(f"def {nt_var}_node_group():", self._outer_indent_level)
         self._write(f'"""Initialize {nt_var} node group"""')
         self._write(f"{nt_var} = bpy.data.node_groups.new("
-                    f"type = \'GeometryNodeTree\', "
-                    f"name = {str_to_py_str(node_tree.name)})\n")
+                    f"type=\'GeometryNodeTree\', "
+                    f"name={str_to_py_str(node_tree.name)})\n")
 
         self._set_node_tree_properties(node_tree)
         if bpy.app.version >= (4, 0, 0):
@@ -147,7 +149,7 @@ class NTPGeoNodesOperator(NTP_Operator):
         #create connections
         self._init_links(node_tree)
         
-        self._write(f"return {nt_var}\n")
+        self._write(f"return {nt_var}\n\n")
 
         #create node group
         self._write(f"{nt_var} = {nt_var}_node_group()\n", self._outer_indent_level)

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -323,7 +323,7 @@ class NTP_Operator(Operator):
         node_var (str): variable name for the node
         """
 
-        self._write(f"#node {node.name}")
+        self._write(f"# Node {node.name}")
 
         node_var = self._create_var(node.name)
         self._node_vars[node] = node_var
@@ -530,11 +530,11 @@ class NTP_Operator(Operator):
                 io_sockets = node.inputs
                 io_socket_interfaces = node_tree.outputs
 
-            self._write(f"#{node_tree_var} {io}s")
+            self._write(f"# {node_tree_var} {io}s")
             for i, inout in enumerate(io_sockets):
                 if inout.bl_idname == 'NodeSocketVirtual':
                     continue
-                self._write(f"#{io} {inout.name}")
+                self._write(f"# {io.capitalize()} {inout.name}")
                 idname = enum_to_py_str(inout.bl_idname)
                 name = str_to_py_str(inout.name)
                 self._write(f"{node_tree_var}.{io}s.new({idname}, {name})")
@@ -642,7 +642,7 @@ class NTP_Operator(Operator):
             ntp_nt (NTP_NodeTree): owner of the socket
             """
 
-            self._write(f"#Socket {socket.name}")
+            self._write(f"# Socket {socket.name}")
             # initialization
             socket_var = self._create_var(socket.name + "_socket") 
             name = str_to_py_str(socket.name)
@@ -755,7 +755,7 @@ class NTP_Operator(Operator):
             ntp_nt (NTP_NodeTree): owner of the socket
             """
 
-            self._write(f"#Panel {panel.name}")
+            self._write(f"# Panel {panel.name}")
 
             panel_var = self._create_var(panel.name + "_panel")
             panel_dict[panel] = panel_var
@@ -840,7 +840,7 @@ class NTP_Operator(Operator):
             ntp_nt (NTP_NodeTree): the node tree to set the interface for
             """
 
-            self._write(f"#{ntp_nt.var} interface")
+            self._write(f"# {ntp_nt.var} interface\n")
             panel_dict: dict[NodeTreeInterfacePanel, str] = {}
             items_processed: set[NodeTreeInterfaceItem] = set()
 
@@ -930,7 +930,7 @@ class NTP_Operator(Operator):
                 else:
                     default_val = input.default_value
                 if default_val is not None:
-                    self._write(f"#{input.identifier}")
+                    self._write(f"# {input.identifier}")
                     self._write(f"{socket_var}.default_value = {default_val}")
         self._write("", 0)
 
@@ -1028,7 +1028,7 @@ class NTP_Operator(Operator):
         self._write("", 0)
 
         # key points
-        self._write(f"#initialize color ramp elements")
+        self._write(f"# Initialize color ramp elements")
         self._write((f"{ramp_str}.elements.remove"
                     f"({ramp_str}.elements[0])"))
         for i, element in enumerate(color_ramp.elements):
@@ -1062,7 +1062,7 @@ class NTP_Operator(Operator):
         node_var = self._node_vars[node]
 
         # mapping settings
-        self._write(f"#mapping settings")
+        self._write(f"# Mapping settings")
         mapping_var = f"{node_var}.{curve_mapping_name}"
 
         # extend
@@ -1098,7 +1098,7 @@ class NTP_Operator(Operator):
             self._create_curve_map(node, i, curve, curve_mapping_name)
 
         # update curve
-        self._write(f"#update curve after changes")
+        self._write(f"# Update curve after changes")
         self._write(f"{mapping_var}.update()")
 
     def _create_curve_map(self, node: Node, i: int, curve: bpy.types.CurveMap,
@@ -1114,7 +1114,7 @@ class NTP_Operator(Operator):
         """
         node_var = self._node_vars[node]
         
-        self._write(f"#curve {i}")
+        self._write(f"# Curve {i}")
         curve_i_var = self._create_var(f"{node_var}_curve_{i}")
         self._write(f"{curve_i_var} = "
                     f"{node_var}.{curve_mapping_name}.curves[{i}]")
@@ -1217,7 +1217,7 @@ class NTP_Operator(Operator):
         img_str = img_to_py_str(img)
 
         # TODO: convert to special variables
-        self._write(f"#load image {img_str}")
+        self._write(f"# Load image {img_str}")
         self._write(f"{BASE_DIR} = "
                     f"os.path.dirname(os.path.abspath(__file__))")
         self._write(f"{IMAGE_PATH} = "
@@ -1227,7 +1227,7 @@ class NTP_Operator(Operator):
                     f"({IMAGE_PATH}, check_existing = True)")
 
         # copy image settings
-        self._write(f"#set image settings")
+        self._write(f"# Set image settings")
 
         # source
         source = enum_to_py_str(img.source)
@@ -1415,7 +1415,7 @@ class NTP_Operator(Operator):
         for node in node_tree.nodes:
             if node is not None and node.parent is not None:
                 if not parent_comment:
-                    self._write(f"#Set parents")
+                    self._write(f"# Set parents")
                     parent_comment = True
                 node_var = self._node_vars[node]
                 parent_var = self._node_vars[node.parent]
@@ -1430,7 +1430,7 @@ class NTP_Operator(Operator):
         node_tree (NodeTree): node tree we're obtaining nodes from
         """
 
-        self._write(f"#Set locations")
+        self._write(f"# Set locations")
         for node in node_tree.nodes:
             node_var = self._node_vars[node]
             self._write(f"{node_var}.location "
@@ -1447,7 +1447,7 @@ class NTP_Operator(Operator):
         if not self._should_set_dimensions:
             return
 
-        self._write(f"#Set dimensions")
+        self._write(f"# Set dimensions")
         for node in node_tree.nodes:
             node_var = self._node_vars[node]
             self._write(f"{node_var}.width, {node_var}.height "
@@ -1466,7 +1466,7 @@ class NTP_Operator(Operator):
 
         links = node_tree.links
         if links:
-            self._write(f"#initialize {nt_var} links")
+            self._write(f"# Initialize {nt_var} links\n")
             if hasattr(links[0], "multi_input_sort_id"):
                 # generate links in the correct order for multi input sockets
                 links = sorted(links, key=lambda link: link.multi_input_sort_id)
@@ -1495,7 +1495,7 @@ class NTP_Operator(Operator):
                     output_idx = i
                     break
 
-            self._write(f"#{in_node_var}.{input_socket.name} "
+            self._write(f"# {in_node_var}.{input_socket.name} "
                         f"-> {out_node_var}.{output_socket.name}")
             self._write(f"{nt_var}.links.new({in_node_var}"
                         f".outputs[{input_idx}], "

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -669,8 +669,8 @@ class NTP_Operator(Operator):
 
             self._write(f"{socket_var} = "
                         f"{ntp_nt.var}.interface.new_socket("
-                        f"name = {name}, in_out={in_out_enum}, "
-                        f"socket_type = {socket_type}"
+                        f"name={name}, in_out={in_out_enum}, "
+                        f"socket_type={socket_type}"
                         f"{optional_parent_str})")
 
             self._set_tree_socket_defaults(socket, socket_var)
@@ -845,8 +845,6 @@ class NTP_Operator(Operator):
             items_processed: set[NodeTreeInterfaceItem] = set()
 
             self._process_items(None, panel_dict, items_processed, ntp_nt)
-
-            self._write("", 0)
 
     def _set_input_defaults(self, node: Node) -> None:
         """
@@ -1420,7 +1418,8 @@ class NTP_Operator(Operator):
                 node_var = self._node_vars[node]
                 parent_var = self._node_vars[node.parent]
                 self._write(f"{node_var}.parent = {parent_var}")
-        self._write("", 0)
+        if parent_comment:
+            self._write("", 0)
 
     def _set_locations(self, node_tree: NodeTree) -> None:
         """
@@ -1435,7 +1434,8 @@ class NTP_Operator(Operator):
             node_var = self._node_vars[node]
             self._write(f"{node_var}.location "
                         f"= ({node.location.x}, {node.location.y})")
-        self._write("", 0)
+        if node_tree.nodes:
+            self._write("", 0)
 
     def _set_dimensions(self, node_tree: NodeTree) -> None:
         """
@@ -1452,7 +1452,8 @@ class NTP_Operator(Operator):
             node_var = self._node_vars[node]
             self._write(f"{node_var}.width, {node_var}.height "
                         f"= {node.width}, {node.height}")
-        self._write("", 0)
+        if node_tree.nodes:
+            self._write("", 0)
 
     def _init_links(self, node_tree: NodeTree) -> None:
         """
@@ -1504,6 +1505,7 @@ class NTP_Operator(Operator):
         for _func in self._write_after_links:
             _func()
         self._write_after_links = []
+        self._write("", 0)
             
 
     def _set_node_tree_properties(self, node_tree: NodeTree) -> None:
@@ -1517,7 +1519,6 @@ class NTP_Operator(Operator):
         if bpy.app.version >= (4, 3, 0):
             default_width = node_tree.default_group_node_width
             self._write(f"{nt_var}.default_group_node_width = {default_width}")
-        self._write("\n")
 
     def _hide_hidden_sockets(self, node: Node) -> None:
         """

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -42,8 +42,8 @@ class NTPShaderOperator(NTP_Operator):
             variable to use
         nt_name (str): name to use for the node tree
         """
-        self._write(f"#initialize {nt_name} node group", self._outer_indent_level)
-        self._write(f"def {ntp_node_tree.var}_node_group():\n", self._outer_indent_level)
+        self._write(f"def {ntp_node_tree.var}_node_group():", self._outer_indent_level)
+        self._write(f'"""Initialize {nt_name} node group"""')
 
         if ntp_node_tree.node_tree == self._base_node_tree:
             self._write(f"{ntp_node_tree.var} = {MAT_VAR}.node_tree")

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -47,7 +47,7 @@ class NTPShaderOperator(NTP_Operator):
 
         if ntp_node_tree.node_tree == self._base_node_tree:
             self._write(f"{ntp_node_tree.var} = {MAT_VAR}.node_tree")
-            self._write(f"#start with a clean node tree")
+            self._write(f"# Start with a clean node tree")
             self._write(f"for {NODE} in {ntp_node_tree.var}.nodes:")
             self._write(f"{ntp_node_tree.var}.nodes.remove({NODE})", self._inner_indent_level + 1)
         else:
@@ -108,7 +108,7 @@ class NTPShaderOperator(NTP_Operator):
             self._tree_interface_settings(ntp_nt)
 
         #initialize nodes
-        self._write(f"#initialize {nt_var} nodes")
+        self._write(f"# Initialize {nt_var} nodes")
 
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -30,7 +30,7 @@ class NTPShaderOperator(NTP_Operator):
     def _create_material(self, indent_level: int):
         self._write(f"{MAT_VAR} = bpy.data.materials.new("
                     f"name = {str_to_py_str(self.material_name)})", indent_level)
-        self._write(f"{MAT_VAR}.use_nodes = True", indent_level)
+        self._write(f"{MAT_VAR}.use_nodes = True\n\n", indent_level)
 
     def _initialize_shader_node_tree(self, ntp_node_tree: NTP_NodeTree, 
                                     nt_name: str) -> None:
@@ -46,7 +46,7 @@ class NTPShaderOperator(NTP_Operator):
         self._write(f'"""Initialize {nt_name} node group"""')
 
         if ntp_node_tree.node_tree == self._base_node_tree:
-            self._write(f"{ntp_node_tree.var} = {MAT_VAR}.node_tree")
+            self._write(f"{ntp_node_tree.var} = {MAT_VAR}.node_tree\n")
             self._write(f"# Start with a clean node tree")
             self._write(f"for {NODE} in {ntp_node_tree.var}.nodes:")
             self._write(f"{ntp_node_tree.var}.nodes.remove({NODE})", self._inner_indent_level + 1)
@@ -108,7 +108,7 @@ class NTPShaderOperator(NTP_Operator):
             self._tree_interface_settings(ntp_nt)
 
         #initialize nodes
-        self._write(f"# Initialize {nt_var} nodes")
+        self._write(f"# Initialize {nt_var} nodes\n")
 
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
@@ -121,7 +121,7 @@ class NTPShaderOperator(NTP_Operator):
         #create connections
         self._init_links(node_tree)
         
-        self._write(f"return {nt_var}\n")
+        self._write(f"return {nt_var}\n\n")
 
         #create node group
         self._write(f"{nt_var} = {nt_var}_node_group()\n", self._outer_indent_level)

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -158,7 +158,7 @@ class NTPShaderOperator(NTP_Operator):
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy, mathutils\n\n")
+                self._file.write("import bpy\nimport mathutils\n\n\n")
 
         if self._mode == 'ADDON':
             self._create_material(2)


### PR DESCRIPTION
Change a few things in the way the scripts are formatted, to better follow usual Python code style (somewhat closer to PEP8 than currently).

- Write docstring instead of comment for initialization function
- Separate each import to its own line
- Comments: add whitespace at line beginning, capitalize first word
- Improve newlines
- Use "var is not None" instead of "var != None"