### PR TITLE
Fix: Add dimensions value on interfaces

### DIFF
--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -673,6 +673,14 @@ class NTP_Operator(Operator):
                         f"socket_type = {socket_type}"
                         f"{optional_parent_str})")
 
+            # vector dimensions
+            if hasattr(socket, "dimensions"):
+                dimensions = socket.dimensions
+                if socket.dimensions != 3:
+                    self._write(f"{socket_var}.dimensions = {dimensions}")
+                    self._write("# Get the socket again, as its default value could have been updated")
+                    self._write(f"{socket_var} = {ntp_nt.var}.interface.items_tree[{socket_var}.index]")
+
             self._set_tree_socket_defaults(socket, socket_var)
 
             # subtype


### PR DESCRIPTION
Since Blender 4.5, Vectors can have a number of dimensions.

The length of the default value array is affected by this, and the socket needs to be retrieved from the items tree again after changing dimensions, otherwise the length may no longer match.