### PR TITLE
Blender 5.0

### DIFF
--- a/NodeToPython/geometry/node_tree.py
+++ b/NodeToPython/geometry/node_tree.py
@@ -1,15 +1,16 @@
 import bpy
-from bpy.types import GeometryNodeTree, GeometryNode
 
 from ..ntp_node_tree import NTP_NodeTree
 
 class NTP_GeoNodeTree(NTP_NodeTree):
-    def __init__(self, node_tree: GeometryNodeTree, var: str):
+    def __init__(self, node_tree: bpy.types.GeometryNodeTree, var: str):
         super().__init__(node_tree, var)
-        self.zone_inputs: dict[str, list[GeometryNode]] = {}
+        self.zone_inputs: dict[str, list[bpy.types.Node]] = {}
         if bpy.app.version >= (3, 6, 0):
             self.zone_inputs["GeometryNodeSimulationInput"] = []
         if bpy.app.version >= (4, 0, 0):
             self.zone_inputs["GeometryNodeRepeatInput"] = []
         if bpy.app.version >= (4, 3, 0):
             self.zone_inputs["GeometryNodeForeachGeometryElementInput"] = []
+        if bpy.app.version >= (5, 0, 0):
+            self.zone_inputs["NodeClosureInput"] = []

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -59,27 +59,27 @@ class NTP_OT_GeometryNodes(NTP_Operator):
             self._set_socket_defaults(node)
 
     if bpy.app.version >= (3, 6, 0):
-        def _process_zones(self, zone_inputs: list[GeometryNode]) -> None:
+        def _process_zones(self, zone_input_list: list[bpy.types.Node]) -> None:
             """
             Recreates a zone
-            zone_inputs (list[GeometryNodeSimulationInput]): list of 
-                simulation input nodes
+            zone_input_list (list[bpy.types.Node]): list of zone input 
+                nodes
             """
-            for zone_input in zone_inputs:
-                zone_output = zone_input.paired_output
+            for input_node in zone_input_list:
+                zone_output = input_node.paired_output
 
-                zone_input_var = self._node_vars[zone_input]
+                zone_input_var = self._node_vars[input_node]
                 zone_output_var = self._node_vars[zone_output]
 
-                self._write(f"# Process zone input {zone_input.name}")
+                self._write(f"# Process zone input {input_node.name}")
                 self._write(f"{zone_input_var}.pair_with_output"
                             f"({zone_output_var})")
 
                 #must set defaults after paired with output
-                self._set_socket_defaults(zone_input)
+                self._set_socket_defaults(input_node)
                 self._set_socket_defaults(zone_output)
 
-            if zone_inputs:
+            if zone_input_list:
                 self._write("", 0)
 
     if bpy.app.version >= (4, 0, 0):

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -106,6 +106,14 @@ class NTP_OT_GeometryNodes(NTP_Operator):
                 for flag in tool_flags:
                     if hasattr(node_tree, flag) is True:
                         self._write(f"{nt_var}.{flag} = {getattr(node_tree, flag)}")
+
+            if bpy.app.version >= (4, 2, 0):
+                if node_tree.use_wait_for_click:
+                    self._write(f"{nt_var}.use_wait_for_click = True")
+                    
+            if bpy.app.version >= (5, 0, 0):
+                if node_tree.show_modifier_manage_panel:
+                    self._write(f"{nt_var}.show_modifier_manager_panel = True")
             self._write("", 0)
 
     def _process_node_tree(self, node_tree: GeometryNodeTree) -> None:

--- a/NodeToPython/node_settings.py
+++ b/NodeToPython/node_settings.py
@@ -19,18 +19,29 @@ class ST(Enum):
 	VEC4 = auto()
 	BAKE_ITEMS = auto()
 	CAPTURE_ATTRIBUTE_ITEMS = auto()
+	CLOSURE_INPUT_ITEMS = auto()
+	CLOSURE_OUTPUT_ITEMS = auto()
+	COLOR_MANAGED_DISPLAY_SETTINGS = auto()
+	COLOR_MANAGED_VIEW_SETTINGS = auto()
 	COLOR_RAMP = auto()
+	COMBINE_BUNDLE_ITEMS = auto()
+	COMPOSITOR_FILE_OUTPUT_ITEMS = auto()
 	CURVE_MAPPING = auto()
 	ENUM_DEFINITION = auto()
 	ENUM_ITEM = auto()
+	EVALUATE_CLOSURE_INPUT_ITEMS = auto()
+	EVALUATE_CLOSURE_OUTPUT_ITEMS = auto()
+	FIELD_TO_GRID_ITEMS = auto()
 	FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
 	FOREACH_GEO_ELEMENT_INPUT_ITEMS = auto()
 	FOREACH_GEO_ELEMENT_MAIN_ITEMS = auto()
 	FORMAT_STRING_ITEMS = auto()
+	GEOMETRY_VIEWER_ITEMS = auto()
 	INDEX_SWITCH_ITEMS = auto()
 	MENU_SWITCH_ITEMS = auto()
 	NODE_TREE = auto()
 	REPEAT_OUTPUT_ITEMS = auto()
+	SEPARATE_BUNDLE_ITEMS = auto()
 	SIM_OUTPUT_ITEMS = auto()
 	IMAGE = auto()
 	IMAGE_USER = auto()
@@ -53,12 +64,12 @@ class NTPNodeSetting(NamedTuple):
 	name_: str
 	st_: ST
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (5, 0, 0)
+	max_version_: tuple = (5, 1, 0)
 
 class NodeInfo(NamedTuple):
 	attributes_: list[NTPNodeSetting]
 	min_version_: tuple = (3, 0, 0)
-	max_version_: tuple = (5, 0, 0)
+	max_version_: tuple = (5, 1, 0)
 
 node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeAlphaOver' : NodeInfo(
@@ -90,7 +101,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("factor", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("factor_x", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("factor_y", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("filter_type", ST.ENUM),
+			NTPNodeSetting("filter_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("size_x", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("size_y", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_bokeh", ST.BOOL, max_version_=(4, 5, 0)),
@@ -123,7 +134,7 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("height", ST.FLOAT, max_version_=(4, 2, 0)),
 			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
-			NTPNodeSetting("mask_type", ST.ENUM),
+			NTPNodeSetting("mask_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("rotation", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("width", ST.FLOAT, max_version_=(4, 2, 0)),
@@ -140,12 +151,12 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeChannelMatte' : NodeInfo(
 		[
-			NTPNodeSetting("color_space", ST.ENUM),
-			NTPNodeSetting("limit_channel", ST.ENUM),
+			NTPNodeSetting("color_space", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("limit_channel", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("limit_max", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("limit_method", ST.ENUM),
+			NTPNodeSetting("limit_method", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("limit_min", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("matte_channel", ST.ENUM),
+			NTPNodeSetting("matte_channel", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -161,7 +172,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeColorBalance' : NodeInfo(
 		[
-			NTPNodeSetting("correction_method", ST.ENUM),
+			NTPNodeSetting("correction_method", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("gain", ST.VEC3, max_version_=(3, 5, 0)),
 			NTPNodeSetting("gain", ST.COLOR, min_version_=(3, 5, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("gamma", ST.VEC3, max_version_=(3, 5, 0)),
@@ -224,9 +235,9 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeColorSpill' : NodeInfo(
 		[
-			NTPNodeSetting("channel", ST.ENUM),
-			NTPNodeSetting("limit_channel", ST.ENUM),
-			NTPNodeSetting("limit_method", ST.ENUM),
+			NTPNodeSetting("channel", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("limit_channel", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("limit_method", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("ratio", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("unspill_blue", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("unspill_green", ST.FLOAT, max_version_=(4, 5, 0)),
@@ -236,21 +247,25 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'CompositorNodeCombHSVA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeCombRGBA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeCombYCCA' : NodeInfo(
 		[
 			NTPNodeSetting("mode", ST.ENUM),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeCombYUVA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeCombineColor' : NodeInfo(
@@ -263,13 +278,15 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeCombineXYZ' : NodeInfo(
 		[],
-		min_version_ = (3, 2, 0)
+		min_version_ = (3, 2, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeComposite' : NodeInfo(
 		[
 			NTPNodeSetting("use_alpha", ST.BOOL, max_version_=(4, 5, 0)),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeConvertColorSpace' : NodeInfo(
@@ -280,9 +297,22 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 1, 0)
 	),
 
+	'CompositorNodeConvertToDisplay' : NodeInfo(
+		[
+			NTPNodeSetting("display_settings", ST.COLOR_MANAGED_DISPLAY_SETTINGS),
+			NTPNodeSetting("view_settings", ST.COLOR_MANAGED_VIEW_SETTINGS),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'CompositorNodeConvolve' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
 	'CompositorNodeCornerPin' : NodeInfo(
 		[
-			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0)),
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0), max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -297,7 +327,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("rel_min_x", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("rel_min_y", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("relative", ST.BOOL, max_version_=(4, 5, 0)),
-			NTPNodeSetting("use_crop_size", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_crop_size", ST.BOOL, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -342,7 +372,8 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeCurveVec' : NodeInfo(
 		[
 			NTPNodeSetting("mapping", ST.CURVE_MAPPING),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeCustomGroup' : NodeInfo(
@@ -381,9 +412,9 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeDenoise' : NodeInfo(
 		[
-			NTPNodeSetting("prefilter", ST.ENUM),
-			NTPNodeSetting("quality", ST.ENUM, min_version_=(4, 4, 0)),
-			NTPNodeSetting("use_hdr", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("prefilter", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("quality", ST.ENUM, min_version_=(4, 4, 0), max_version_=(5, 0, 0)),
+			NTPNodeSetting("use_hdr", ST.BOOL, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -405,8 +436,8 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("distance", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("edge", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("falloff", ST.ENUM),
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("falloff", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -416,7 +447,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeDistanceMatte' : NodeInfo(
 		[
-			NTPNodeSetting("channel", ST.ENUM),
+			NTPNodeSetting("channel", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("falloff", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
@@ -424,8 +455,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeDoubleEdgeMask' : NodeInfo(
 		[
-			NTPNodeSetting("edge_mode", ST.ENUM),
-			NTPNodeSetting("inner_mode", ST.ENUM),
+			NTPNodeSetting("edge_mode", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("inner_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -433,7 +464,7 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("height", ST.FLOAT, max_version_=(4, 2, 0)),
 			NTPNodeSetting("mask_height", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
-			NTPNodeSetting("mask_type", ST.ENUM),
+			NTPNodeSetting("mask_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("mask_width", ST.FLOAT, min_version_=(4, 2, 0), max_version_=(4, 5, 0)),
 			NTPNodeSetting("rotation", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("width", ST.FLOAT, max_version_=(4, 2, 0)),
@@ -448,7 +479,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeFilter' : NodeInfo(
 		[
-			NTPNodeSetting("filter_type", ST.ENUM),
+			NTPNodeSetting("filter_type", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -467,14 +498,14 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("angle_offset", ST.FLOAT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("color_modulation", ST.FLOAT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("fade", ST.FLOAT, max_version_=(4, 4, 0)),
-			NTPNodeSetting("glare_type", ST.ENUM),
+			NTPNodeSetting("glare_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("iterations", ST.INT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("mix", ST.FLOAT, max_version_=(4, 4, 0)),
-			NTPNodeSetting("quality", ST.ENUM),
+			NTPNodeSetting("quality", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("size", ST.INT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("streaks", ST.INT, max_version_=(4, 4, 0)),
 			NTPNodeSetting("threshold", ST.FLOAT, max_version_=(4, 4, 0)),
-			NTPNodeSetting("use_rotate_45", ST.BOOL, max_version_=(4, 4, 0)),
+			NTPNodeSetting("use_rotate_45", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
 
@@ -510,7 +541,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("layer", ST.ENUM),
 			NTPNodeSetting("use_auto_refresh", ST.BOOL),
 			NTPNodeSetting("use_cyclic", ST.BOOL),
-			NTPNodeSetting("use_straight_alpha_output", ST.BOOL, max_version_=(4, 5, 0)),
+			NTPNodeSetting("use_straight_alpha_output", ST.BOOL, max_version_=(5, 0, 0)),
 			NTPNodeSetting("view", ST.ENUM),
 		]
 	),
@@ -550,7 +581,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("edge_kernel_radius", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("edge_kernel_tolerance", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("feather_distance", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("feather_falloff", ST.ENUM),
+			NTPNodeSetting("feather_falloff", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("screen_balance", ST.FLOAT, max_version_=(4, 5, 0)),
 		]
 	),
@@ -570,14 +601,14 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("size", ST.INT, max_version_=(4, 1, 0)),
 			NTPNodeSetting("uniformity", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_high_precision", ST.BOOL, min_version_=(4, 1, 0), max_version_=(4, 5, 0)),
-			NTPNodeSetting("variation", ST.ENUM),
+			NTPNodeSetting("variation", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (4, 0, 0)
 	),
 
 	'CompositorNodeLensdist' : NodeInfo(
 		[
-			NTPNodeSetting("distortion_type", ST.ENUM, min_version_=(4, 5, 0)),
+			NTPNodeSetting("distortion_type", ST.ENUM, min_version_=(4, 5, 0), max_version_=(5, 0, 0)),
 			NTPNodeSetting("use_fit", ST.BOOL, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_jitter", ST.BOOL, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_projector", ST.BOOL, max_version_=(4, 5, 0)),
@@ -586,27 +617,28 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeLevels' : NodeInfo(
 		[
-			NTPNodeSetting("channel", ST.ENUM),
+			NTPNodeSetting("channel", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeLumaMatte' : NodeInfo(
 		[
-			NTPNodeSetting("limit_max", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("limit_min", ST.FLOAT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("limit_max", ST.FLOAT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("limit_min", ST.FLOAT, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeMapRange' : NodeInfo(
 		[
 			NTPNodeSetting("use_clamp", ST.BOOL),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeMapUV' : NodeInfo(
 		[
 			NTPNodeSetting("alpha", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("filter_type", ST.ENUM, min_version_=(4, 1, 0)),
+			NTPNodeSetting("filter_type", ST.ENUM, min_version_=(4, 1, 0), max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -618,7 +650,8 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("size", ST.VEC1),
 			NTPNodeSetting("use_max", ST.BOOL),
 			NTPNodeSetting("use_min", ST.BOOL),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeMask' : NodeInfo(
@@ -626,7 +659,7 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("mask", ST.MASK),
 			NTPNodeSetting("motion_blur_samples", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("motion_blur_shutter", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("size_source", ST.ENUM),
+			NTPNodeSetting("size_source", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("size_x", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("size_y", ST.INT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("use_feather", ST.BOOL, max_version_=(4, 5, 0)),
@@ -638,7 +671,8 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("operation", ST.ENUM),
 			NTPNodeSetting("use_clamp", ST.BOOL),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeMixRGB' : NodeInfo(
@@ -646,7 +680,8 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("blend_type", ST.ENUM),
 			NTPNodeSetting("use_alpha", ST.BOOL),
 			NTPNodeSetting("use_clamp", ST.BOOL),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeMovieClip' : NodeInfo(
@@ -658,7 +693,7 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeMovieDistortion' : NodeInfo(
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
-			NTPNodeSetting("distortion_type", ST.ENUM),
+			NTPNodeSetting("distortion_type", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -672,11 +707,15 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeOutputFile' : NodeInfo(
 		[
-			NTPNodeSetting("active_input_index", ST.INT),
-			NTPNodeSetting("base_path", ST.STRING),
-			NTPNodeSetting("file_slots", ST.FILE_SLOTS),
+			NTPNodeSetting("active_input_index", ST.INT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("active_item_index", ST.INT, min_version_=(5, 0, 0)),
+			NTPNodeSetting("base_path", ST.STRING, max_version_=(5, 0, 0)),
+			NTPNodeSetting("directory", ST.STRING, min_version_=(5, 0, 0)),
+			NTPNodeSetting("file_name", ST.STRING, min_version_=(5, 0, 0)),
+			NTPNodeSetting("file_output_items", ST.COMPOSITOR_FILE_OUTPUT_ITEMS, min_version_=(5, 0, 0)),
+			NTPNodeSetting("file_slots", ST.FILE_SLOTS, max_version_=(5, 0, 0)),
 			NTPNodeSetting("format", ST.IMAGE_FORMAT_SETTINGS),
-			NTPNodeSetting("layer_slots", ST.LAYER_SLOTS),
+			NTPNodeSetting("layer_slots", ST.LAYER_SLOTS, max_version_=(5, 0, 0)),
 			NTPNodeSetting("save_as_render", ST.BOOL, min_version_=(4, 3, 0)),
 		]
 	),
@@ -704,7 +743,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodePremulKey' : NodeInfo(
 		[
-			NTPNodeSetting("mapping", ST.ENUM),
+			NTPNodeSetting("mapping", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -733,17 +772,17 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeRotate' : NodeInfo(
 		[
-			NTPNodeSetting("filter_type", ST.ENUM),
+			NTPNodeSetting("filter_type", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeScale' : NodeInfo(
 		[
-			NTPNodeSetting("frame_method", ST.ENUM),
-			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0)),
+			NTPNodeSetting("frame_method", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 5, 0), max_version_=(5, 0, 0)),
 			NTPNodeSetting("offset_x", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("offset_y", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("space", ST.ENUM),
+			NTPNodeSetting("space", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -753,21 +792,25 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'CompositorNodeSepHSVA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSepRGBA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSepYCCA' : NodeInfo(
 		[
 			NTPNodeSetting("mode", ST.ENUM),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSepYUVA' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSeparateColor' : NodeInfo(
@@ -780,19 +823,20 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeSeparateXYZ' : NodeInfo(
 		[],
-		min_version_ = (3, 2, 0)
+		min_version_ = (3, 2, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSetAlpha' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeSplit' : NodeInfo(
 		[
-			NTPNodeSetting("axis", ST.ENUM),
-			NTPNodeSetting("factor", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("axis", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("factor", ST.INT, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (4, 1, 0)
 	),
@@ -808,7 +852,7 @@ node_settings : dict[str, NodeInfo] = {
 	'CompositorNodeStabilize' : NodeInfo(
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
-			NTPNodeSetting("filter_type", ST.ENUM),
+			NTPNodeSetting("filter_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("invert", ST.BOOL, max_version_=(4, 5, 0)),
 		]
 	),
@@ -817,7 +861,8 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("ray_length", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("source", ST.VEC2, max_version_=(4, 5, 0)),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeSwitch' : NodeInfo(
@@ -834,14 +879,15 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("node_output", ST.INT),
 			NTPNodeSetting("texture", ST.TEXTURE),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeTime' : NodeInfo(
 		[
 			NTPNodeSetting("curve", ST.CURVE_MAPPING),
-			NTPNodeSetting("frame_end", ST.INT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("frame_start", ST.INT, max_version_=(4, 5, 0)),
+			NTPNodeSetting("frame_end", ST.INT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("frame_start", ST.INT, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -854,15 +900,15 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("intensity", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("key", ST.FLOAT, max_version_=(4, 5, 0)),
 			NTPNodeSetting("offset", ST.FLOAT, max_version_=(4, 5, 0)),
-			NTPNodeSetting("tonemap_type", ST.ENUM),
+			NTPNodeSetting("tonemap_type", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeTrackPos' : NodeInfo(
 		[
 			NTPNodeSetting("clip", ST.MOVIE_CLIP),
-			NTPNodeSetting("frame_relative", ST.INT),
-			NTPNodeSetting("position", ST.ENUM),
+			NTPNodeSetting("frame_relative", ST.INT, max_version_=(5, 0, 0)),
+			NTPNodeSetting("position", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("track_name", ST.STRING),
 			NTPNodeSetting("tracking_object", ST.STRING),
 		]
@@ -870,26 +916,28 @@ node_settings : dict[str, NodeInfo] = {
 
 	'CompositorNodeTransform' : NodeInfo(
 		[
-			NTPNodeSetting("filter_type", ST.ENUM),
+			NTPNodeSetting("filter_type", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeTranslate' : NodeInfo(
 		[
-			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 2, 0)),
+			NTPNodeSetting("interpolation", ST.ENUM, min_version_=(4, 2, 0), max_version_=(5, 0, 0)),
 			NTPNodeSetting("use_relative", ST.BOOL, max_version_=(4, 5, 0)),
-			NTPNodeSetting("wrap_axis", ST.ENUM),
+			NTPNodeSetting("wrap_axis", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'CompositorNodeValToRGB' : NodeInfo(
 		[
 			NTPNodeSetting("color_ramp", ST.COLOR_RAMP),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeValue' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'CompositorNodeVecBlur' : NodeInfo(
@@ -1090,7 +1138,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'FunctionNodeMatchString' : NodeInfo(
 		[
-			NTPNodeSetting("operation", ST.ENUM),
+			NTPNodeSetting("operation", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (4, 5, 0)
 	),
@@ -1185,6 +1233,13 @@ node_settings : dict[str, NodeInfo] = {
 		[]
 	),
 
+	'FunctionNodeStringToValue' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
 	'FunctionNodeTransformDirection' : NodeInfo(
 		[],
 		min_version_ = (4, 2, 0)
@@ -1277,7 +1332,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeClosureInput' : NodeInfo(
 		[],
-		min_version_ = (4, 5, 0)
+		min_version_ = (4, 5, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeClosureOutput' : NodeInfo(
@@ -1285,7 +1341,8 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("active_input_index", ST.INT),
 			NTPNodeSetting("active_output_index", ST.INT),
 		],
-		min_version_ = (4, 5, 0)
+		min_version_ = (4, 5, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeCollectionInfo' : NodeInfo(
@@ -1298,7 +1355,8 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("active_index", ST.INT),
 		],
-		min_version_ = (4, 5, 0)
+		min_version_ = (4, 5, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeConvexHull' : NodeInfo(
@@ -1443,7 +1501,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeDistributePointsInVolume' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 4, 0)
 	),
@@ -1497,7 +1555,8 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("active_input_index", ST.INT),
 			NTPNodeSetting("active_output_index", ST.INT),
 		],
-		min_version_ = (4, 5, 0)
+		min_version_ = (4, 5, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeExtrudeMesh' : NodeInfo(
@@ -1544,6 +1603,15 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 3, 0)
 	),
 
+	'GeometryNodeFieldToGrid' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("grid_items", ST.FIELD_TO_GRID_ITEMS),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
 	'GeometryNodeFieldVariance' : NodeInfo(
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
@@ -1554,13 +1622,13 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeFillCurve' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
 	'GeometryNodeFilletCurve' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -1635,6 +1703,28 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (4, 3, 0)
 	),
 
+	'GeometryNodeGridAdvect' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeGridCurl' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeGridDivergence' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeGridGradient' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
 	'GeometryNodeGridInfo' : NodeInfo(
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
@@ -1642,9 +1732,28 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (4, 5, 0)
 	),
 
+	'GeometryNodeGridLaplacian' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeGridPrune' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
 	'GeometryNodeGridToMesh' : NodeInfo(
 		[],
 		min_version_ = (4, 2, 0)
+	),
+
+	'GeometryNodeGridVoxelize' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeGroup' : NodeInfo(
@@ -1876,6 +1985,11 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeInputTangent' : NodeInfo(
 		[]
+	),
+
+	'GeometryNodeInputVoxelIndex' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeInstanceOnPoints' : NodeInfo(
@@ -2206,6 +2320,27 @@ node_settings : dict[str, NodeInfo] = {
 		max_version_ = (3, 2, 0)
 	),
 
+	'GeometryNodeList' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeListGetItem' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeListLength' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
 	'GeometryNodeMaterialSelection' : NodeInfo(
 		[]
 	),
@@ -2229,7 +2364,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeMergeByDistance' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM, min_version_=(3, 2, 0)),
+			NTPNodeSetting("mode", ST.ENUM, min_version_=(3, 2, 0), max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 1, 0)
 	),
@@ -2322,7 +2457,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeMeshToVolume' : NodeInfo(
 		[
-			NTPNodeSetting("resolution_mode", ST.ENUM),
+			NTPNodeSetting("resolution_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 3, 0)
 	),
@@ -2387,7 +2522,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodePointsToVolume' : NodeInfo(
 		[
-			NTPNodeSetting("resolution_mode", ST.ENUM),
+			NTPNodeSetting("resolution_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2400,7 +2535,7 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeRaycast' : NodeInfo(
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
-			NTPNodeSetting("mapping", ST.ENUM),
+			NTPNodeSetting("mapping", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2412,7 +2547,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeRemoveAttribute' : NodeInfo(
 		[
-			NTPNodeSetting("pattern_mode", ST.ENUM, min_version_=(4, 2, 0)),
+			NTPNodeSetting("pattern_mode", ST.ENUM, min_version_=(4, 2, 0), max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 2, 0)
 	),
@@ -2438,7 +2573,7 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeResampleCurve' : NodeInfo(
 		[
 			NTPNodeSetting("keep_last_segment", ST.BOOL, min_version_=(4, 4, 0)),
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2455,6 +2590,36 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("operation", ST.ENUM),
 		],
 		min_version_ = (4, 2, 0)
+	),
+
+	'GeometryNodeSDFGridFillet' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSDFGridLaplacian' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSDFGridMean' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSDFGridMeanCurvature' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSDFGridMedian' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSDFGridOffset' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeSDFVolumeSphere' : NodeInfo(
@@ -2474,7 +2639,7 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeSampleGrid' : NodeInfo(
 		[
 			NTPNodeSetting("data_type", ST.ENUM),
-			NTPNodeSetting("interpolation_mode", ST.ENUM),
+			NTPNodeSetting("interpolation_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (4, 2, 0)
 	),
@@ -2528,7 +2693,7 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeScaleElements' : NodeInfo(
 		[
 			NTPNodeSetting("domain", ST.ENUM),
-			NTPNodeSetting("scale_mode", ST.ENUM),
+			NTPNodeSetting("scale_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 1, 0)
 	),
@@ -2546,7 +2711,8 @@ node_settings : dict[str, NodeInfo] = {
 		[
 			NTPNodeSetting("active_index", ST.INT),
 		],
-		min_version_ = (4, 5, 0)
+		min_version_ = (4, 5, 0),
+		max_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeSeparateComponents' : NodeInfo(
@@ -2567,7 +2733,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeSetCurveNormal' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM),
+			NTPNodeSetting("mode", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 4, 0)
 	),
@@ -2602,6 +2768,20 @@ node_settings : dict[str, NodeInfo] = {
 	'GeometryNodeSetGreasePencilSoftness' : NodeInfo(
 		[],
 		min_version_ = (4, 5, 0)
+	),
+
+	'GeometryNodeSetGridBackground' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'GeometryNodeSetGridTransform' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
 	),
 
 	'GeometryNodeSetID' : NodeInfo(
@@ -2730,8 +2910,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeSubdivisionSurface' : NodeInfo(
 		[
-			NTPNodeSetting("boundary_smooth", ST.ENUM),
-			NTPNodeSetting("uv_smooth", ST.ENUM),
+			NTPNodeSetting("boundary_smooth", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("uv_smooth", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2783,7 +2963,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeTransform' : NodeInfo(
 		[
-			NTPNodeSetting("mode", ST.ENUM, min_version_=(4, 2, 0)),
+			NTPNodeSetting("mode", ST.ENUM, min_version_=(4, 2, 0), max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2793,8 +2973,8 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeTriangulate' : NodeInfo(
 		[
-			NTPNodeSetting("ngon_method", ST.ENUM),
-			NTPNodeSetting("quad_method", ST.ENUM),
+			NTPNodeSetting("ngon_method", ST.ENUM, max_version_=(5, 0, 0)),
+			NTPNodeSetting("quad_method", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2809,9 +2989,14 @@ node_settings : dict[str, NodeInfo] = {
 		min_version_ = (3, 3, 0)
 	),
 
+	'GeometryNodeUVTangent' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
 	'GeometryNodeUVUnwrap' : NodeInfo(
 		[
-			NTPNodeSetting("method", ST.ENUM),
+			NTPNodeSetting("method", ST.ENUM, max_version_=(5, 0, 0)),
 		],
 		min_version_ = (3, 3, 0)
 	),
@@ -2823,9 +3008,11 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeViewer' : NodeInfo(
 		[
-			NTPNodeSetting("data_type", ST.ENUM),
+			NTPNodeSetting("active_index", ST.INT, min_version_=(5, 0, 0)),
+			NTPNodeSetting("data_type", ST.ENUM, max_version_=(5, 0, 0)),
 			NTPNodeSetting("domain", ST.ENUM, min_version_=(3, 4, 0)),
 			NTPNodeSetting("ui_shortcut", ST.INT, min_version_=(4, 5, 0)),
+			NTPNodeSetting("viewer_items", ST.GEOMETRY_VIEWER_ITEMS, min_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2841,7 +3028,7 @@ node_settings : dict[str, NodeInfo] = {
 
 	'GeometryNodeVolumeToMesh' : NodeInfo(
 		[
-			NTPNodeSetting("resolution_mode", ST.ENUM),
+			NTPNodeSetting("resolution_mode", ST.ENUM, max_version_=(5, 0, 0)),
 		]
 	),
 
@@ -2850,6 +3037,49 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("warning_type", ST.ENUM),
 		],
 		min_version_ = (4, 3, 0)
+	),
+
+	'NodeClosureInput' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
+	'NodeClosureOutput' : NodeInfo(
+		[
+			NTPNodeSetting("active_input_index", ST.INT),
+			NTPNodeSetting("active_output_index", ST.INT),
+			NTPNodeSetting("define_signature", ST.BOOL),
+			NTPNodeSetting("input_items", ST.CLOSURE_INPUT_ITEMS),
+			NTPNodeSetting("output_items", ST.CLOSURE_OUTPUT_ITEMS),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'NodeCombineBundle' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+			NTPNodeSetting("bundle_items", ST.COMBINE_BUNDLE_ITEMS),
+			NTPNodeSetting("define_signature", ST.BOOL),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'NodeEnableOutput' : NodeInfo(
+		[
+			NTPNodeSetting("data_type", ST.ENUM),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
+	'NodeEvaluateClosure' : NodeInfo(
+		[
+			NTPNodeSetting("active_input_index", ST.INT),
+			NTPNodeSetting("active_output_index", ST.INT),
+			NTPNodeSetting("define_signature", ST.BOOL),
+			NTPNodeSetting("input_items", ST.EVALUATE_CLOSURE_OUTPUT_ITEMS),
+			NTPNodeSetting("output_items", ST.EVALUATE_CLOSURE_OUTPUT_ITEMS),
+		],
+		min_version_ = (5, 0, 0)
 	),
 
 	'NodeFrame' : NodeInfo(
@@ -2876,10 +3106,24 @@ node_settings : dict[str, NodeInfo] = {
 		]
 	),
 
+	'NodeJoinBundle' : NodeInfo(
+		[],
+		min_version_ = (5, 0, 0)
+	),
+
 	'NodeReroute' : NodeInfo(
 		[
 			NTPNodeSetting("socket_idname", ST.STRING, min_version_=(4, 3, 0)),
 		]
+	),
+
+	'NodeSeparateBundle' : NodeInfo(
+		[
+			NTPNodeSetting("active_index", ST.INT),
+			NTPNodeSetting("bundle_items", ST.SEPARATE_BUNDLE_ITEMS),
+			NTPNodeSetting("define_signature", ST.BOOL),
+		],
+		min_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeAddShader' : NodeInfo(
@@ -3031,11 +3275,13 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'ShaderNodeCombineHSV' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeCombineRGB' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeCombineXYZ' : NodeInfo(
@@ -3234,6 +3480,13 @@ node_settings : dict[str, NodeInfo] = {
 		[]
 	),
 
+	'ShaderNodeRadialTiling' : NodeInfo(
+		[
+			NTPNodeSetting("normalize", ST.BOOL),
+		],
+		min_version_ = (5, 0, 0)
+	),
+
 	'ShaderNodeScript' : NodeInfo(
 		[
 			NTPNodeSetting("bytecode", ST.STRING),
@@ -3253,11 +3506,13 @@ node_settings : dict[str, NodeInfo] = {
 	),
 
 	'ShaderNodeSeparateHSV' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeSeparateRGB' : NodeInfo(
-		[]
+		[],
+		max_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeSeparateXYZ' : NodeInfo(
@@ -3381,14 +3636,16 @@ node_settings : dict[str, NodeInfo] = {
 			NTPNodeSetting("space", ST.ENUM),
 			NTPNodeSetting("vertex_attribute_name", ST.STRING),
 			NTPNodeSetting("vertex_color_source", ST.ENUM),
-		]
+		],
+		max_version_ = (5, 0, 0)
 	),
 
 	'ShaderNodeTexSky' : NodeInfo(
 		[
+			NTPNodeSetting("aerosol_density", ST.FLOAT, min_version_=(5, 0, 0)),
 			NTPNodeSetting("air_density", ST.FLOAT),
 			NTPNodeSetting("altitude", ST.FLOAT),
-			NTPNodeSetting("dust_density", ST.FLOAT),
+			NTPNodeSetting("dust_density", ST.FLOAT, max_version_=(5, 0, 0)),
 			NTPNodeSetting("ground_albedo", ST.FLOAT),
 			NTPNodeSetting("ozone_density", ST.FLOAT),
 			NTPNodeSetting("sky_type", ST.ENUM),

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -776,6 +776,11 @@ class NTP_Operator(Operator):
                 structure_type = enum_to_py_str(socket.structure_type)
                 self._write(f"{socket_var}.structure_type = {structure_type}")
 
+            if bpy.app.version >= (5, 0, 0):
+                # optional label
+                if socket.optional_label:
+                    self._write(f"{socket_var}.optional_label = True")
+
             self._write("", 0)
 
         def _create_panel(self, panel: NodeTreeInterfacePanel, 

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -1558,8 +1558,14 @@ class NTP_Operator(Operator):
                 
                 items_str = f"{geometry_viewer_items_str}[{i}]"
                 
-                # Uncomment when https://projects.blender.org/blender/blender/issues/147907 is resolved
-                #self._write(f"{items_str}.auto_remove = {item.auto_remove}")
+                # auto remove will automatically remove input if not linked
+                # need to initialize after links
+                auto_remove_str = f"{items_str}.auto_remove = {item.auto_remove}"
+                self._write_after_links.append(
+                    lambda _auto_remove_str = auto_remove_str: (
+                        self._write(_auto_remove_str)
+                    )
+                )
         
         def _compositor_file_output_items(self,
             compositor_file_output_items: bpy.types.NodeCompositorFileOutputItems,

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -444,38 +444,38 @@ class NTP_Operator(Operator):
                 if self._addon_dir is not None:
                     if attr.source in {'FILE', 'GENERATED', 'TILED'}:
                         if self._save_image(attr):
-                            self._load_image(attr, f"{node_var}.{attr_name}")
+                            self._load_image(attr, setting_str)
                 else:
                     self._set_if_in_blend_file(attr, setting_str, "images")
 
             elif st == ST.IMAGE_USER:
-                self._image_user_settings(attr, f"{node_var}.{attr_name}")
+                self._image_user_settings(attr, setting_str)
             elif st == ST.SIM_OUTPUT_ITEMS:
-                self._output_zone_items(attr, f"{node_var}.{attr_name}", True)
+                self._output_zone_items(attr, setting_str, True)
             elif st == ST.REPEAT_OUTPUT_ITEMS:
-                self._output_zone_items(attr, f"{node_var}.{attr_name}", False)
+                self._output_zone_items(attr, setting_str, False)
             elif st == ST.INDEX_SWITCH_ITEMS:
-                self._index_switch_items(attr, f"{node_var}.{attr_name}")
+                self._index_switch_items(attr, setting_str)
             elif st == ST.ENUM_DEFINITION:
-                self._enum_definition(attr, f"{node_var}.{attr_name}")
+                self._enum_definition(attr, setting_str)
             elif st == ST.BAKE_ITEMS:
-                self._bake_items(attr, f"{node_var}.{attr_name}")
+                self._bake_items(attr, setting_str)
             elif st == ST.CAPTURE_ATTRIBUTE_ITEMS:
-                self._capture_attribute_items(attr, f"{node_var}.{attr_name}")
+                self._capture_attribute_items(attr, setting_str)
             elif st == ST.MENU_SWITCH_ITEMS:
-                self._menu_switch_items(attr, f"{node_var}.{attr_name}")
+                self._menu_switch_items(attr, setting_str)
             elif st == ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS:
-                self._foreach_geo_element_generation_items(attr, f"{node_var}.{attr_name}")
+                self._foreach_geo_element_generation_items(attr, setting_str)
             elif st == ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS:
-                self._foreach_geo_element_input_items(attr, f"{node_var}.{attr_name}")
+                self._foreach_geo_element_input_items(attr, setting_str)
             elif st == ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS:
-                self._foreach_geo_element_main_items(attr, f"{node_var}.{attr_name}")
+                self._foreach_geo_element_main_items(attr, setting_str)
             elif st == ST.FORMAT_STRING_ITEMS:
-                self._format_string_items(attr, f"{node_var}.{attr_name}")
+                self._format_string_items(attr, setting_str)
             elif st == ST.CLOSURE_INPUT_ITEMS:
-                self._closure_input_items(attr, f"{node_var}.{attr_name}")
+                self._closure_input_items(attr, setting_str)
             elif st == ST.CLOSURE_OUTPUT_ITEMS:
-                self._closure_output_items(attr, f"{node_var}.{attr_name}")
+                self._closure_output_items(attr, setting_str)
             elif st == ST.COLOR_MANAGED_DISPLAY_SETTINGS:
                 pass
             elif st == ST.COLOR_MANAGED_VIEW_SETTINGS:
@@ -483,17 +483,17 @@ class NTP_Operator(Operator):
             elif st == ST.COMPOSITOR_FILE_OUTPUT_ITEMS:
                 self._compositor_file_output_items(attr, setting_str)
             elif st == ST.EVALUATE_CLOSURE_INPUT_ITEMS:
-                self._evaluate_closure_input_items(attr, f"{node_var}.{attr_name}")
+                self._evaluate_closure_input_items(attr, setting_str)
             elif st == ST.EVALUATE_CLOSURE_OUTPUT_ITEMS:
-                self._evaluate_closure_output_items(attr, f"{node_var}.{attr_name}")
+                self._evaluate_closure_output_items(attr, setting_str)
             elif st == ST.FIELD_TO_GRID_ITEMS:
-                self._field_to_grid_items(attr, f"{node_var}.{attr_name}")
+                self._field_to_grid_items(attr, setting_str)
             elif st == ST.GEOMETRY_VIEWER_ITEMS:
-                self._geometry_viewer_items(attr, f"{node_var}.{attr_name}")
+                self._geometry_viewer_items(attr, setting_str)
             elif st == ST.COMBINE_BUNDLE_ITEMS:
-                self._combine_bundle_items(attr, f"{node_var}.{attr_name}")
+                self._combine_bundle_items(attr, setting_str)
             elif st == ST.SEPARATE_BUNDLE_ITEMS:
-                self._separate_bundle_items(attr, f"{node_var}.{attr_name}")
+                self._separate_bundle_items(attr, setting_str)
 
     if bpy.app.version < (4, 0, 0):
         def _set_group_socket_defaults(self, socket_interface: NodeSocketInterface,

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -487,7 +487,7 @@ class NTP_Operator(Operator):
             elif st == ST.EVALUATE_CLOSURE_OUTPUT_ITEMS:
                 self._evaluate_closure_output_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.FIELD_TO_GRID_ITEMS:
-                pass
+                self._field_to_grid_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.GEOMETRY_VIEWER_ITEMS:
                 pass
             elif st == ST.COMBINE_BUNDLE_ITEMS:
@@ -1534,6 +1534,17 @@ class NTP_Operator(Operator):
                 structure_type = enum_to_py_str(item.structure_type)
                 self._write(f"{item_str}.structure_type = {structure_type}")
 
+        def _field_to_grid_items(self,
+            field_to_grid_items: bpy.types.GeometryNodeFieldToGridItems,
+            field_to_grid_items_str : str,
+        ) -> None:
+            self._write(f"{field_to_grid_items_str}.clear()")
+            for i, item in enumerate(field_to_grid_items):
+                data_type = enum_to_py_str(item.data_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{field_to_grid_items_str}.new("
+                             f"{data_type}, {name_str})"))
+                
 
     def _set_parents(self, node_tree: NodeTree) -> None:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -36,10 +36,14 @@ RESERVED_NAMES = {
                  }
 
 #node input sockets that are messy to set default values for
-DONT_SET_DEFAULTS = {'NodeSocketGeometry',
-                     'NodeSocketShader',
-                     'NodeSocketMatrix',
-                     'NodeSocketVirtual'}
+DONT_SET_DEFAULTS = {
+    'NodeSocketGeometry',
+    'NodeSocketShader',
+    'NodeSocketMatrix',
+    'NodeSocketVirtual',
+    'NodeSocketBundle',
+    'NodeSocketClosure'
+}
 
 MAX_BLENDER_VERSION = (5, 0, 0)
 
@@ -63,7 +67,8 @@ class NTP_Operator(Operator):
             bpy.types.NodeTreeInterfaceSocketMaterial,
             bpy.types.NodeTreeInterfaceSocketObject,
             bpy.types.NodeTreeInterfaceSocketShader,
-            bpy.types.NodeTreeInterfaceSocketTexture
+            bpy.types.NodeTreeInterfaceSocketTexture,
+            bpy.types.NodeTreeInterfaceSocketClosure
         }
 
     def __init__(self, *args, **kwargs):
@@ -467,6 +472,28 @@ class NTP_Operator(Operator):
                 self._foreach_geo_element_main_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.FORMAT_STRING_ITEMS:
                 self._format_string_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.CLOSURE_INPUT_ITEMS:
+                self._closure_input_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.CLOSURE_OUTPUT_ITEMS:
+                self._closure_output_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.COLOR_MANAGED_DISPLAY_SETTINGS:
+                pass
+            elif st == ST.COLOR_MANAGED_VIEW_SETTINGS:
+                pass
+            elif st == ST.COMPOSITOR_FILE_OUTPUT_ITEMS:
+                pass
+            elif st == ST.EVALUATE_CLOSURE_INPUT_ITEMS:
+                self._evaluate_closure_input_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.EVALUATE_CLOSURE_OUTPUT_ITEMS:
+                self._evaluate_closure_output_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.FIELD_TO_GRID_ITEMS:
+                pass
+            elif st == ST.GEOMETRY_VIEWER_ITEMS:
+                pass
+            elif st == ST.COMBINE_BUNDLE_ITEMS:
+                self._combine_bundle_items(attr, f"{node_var}.{attr_name}")
+            elif st == ST.SEPARATE_BUNDLE_ITEMS:
+                self._separate_bundle_items(attr, f"{node_var}.{attr_name}")
 
     if bpy.app.version < (4, 0, 0):
         def _set_group_socket_defaults(self, socket_interface: NodeSocketInterface,
@@ -1401,13 +1428,111 @@ class NTP_Operator(Operator):
 
     if bpy.app.version >= (4, 5, 0):
         def _format_string_items(self,
-                          format_items : bpy.types.NodeFunctionFormatStringItems,
-                          format_items_str: str) -> None:
+            format_items : bpy.types.NodeFunctionFormatStringItems,
+            format_items_str: str
+        ) -> None:
             self._write(f"{format_items_str}.clear()")
             for i, item in enumerate(format_items):
                 socket_type = enum_to_py_str(item.socket_type)
                 name_str = str_to_py_str(item.name)
                 self._write(f"{format_items_str}.new({socket_type}, {name_str})")
+
+    if bpy.app.version >= (5, 0, 0):
+        def _closure_input_items(self,
+            closure_input_items : bpy.types.NodeClosureInputItems,
+            closure_input_items_str : str
+        ) -> None:
+            self._write(f"{closure_input_items_str}.clear()")
+            for i, item in enumerate(closure_input_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{closure_input_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{closure_input_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
+
+        def _closure_output_items(self,
+            closure_output_items : bpy.types.NodeClosureOutputItems,
+            closure_output_items_str : str
+        ) -> None:
+            self._write(f"{closure_output_items_str}.clear()")
+            for i, item in enumerate(closure_output_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{closure_output_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{closure_output_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
+
+        def _evaluate_closure_input_items(self,
+            evaluate_closure_input_items : bpy.types.NodeEvaluateClosureInputItems,
+            evaluate_closure_input_items_str : str
+        ) -> None:
+            self._write(f"{evaluate_closure_input_items_str}.clear()")
+            for i, item in enumerate(evaluate_closure_input_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{evaluate_closure_input_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{evaluate_closure_input_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
+
+        def _evaluate_closure_output_items(self,
+            evaluate_closure_output_items : bpy.types.NodeEvaluateClosureOutputItems,
+            evaluate_closure_output_items_str : str
+        ) -> None:
+            self._write(f"{evaluate_closure_output_items_str}.clear()")
+            for i, item in enumerate(evaluate_closure_output_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{evaluate_closure_output_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{evaluate_closure_output_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
+        
+        def _combine_bundle_items(self,
+            combine_bundle_items : bpy.types.NodeCombineBundleItems,
+            combine_bundle_items_str : str
+        ) -> None:
+            self._write(f"{combine_bundle_items_str}.clear()")
+            for i, item in enumerate(combine_bundle_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{combine_bundle_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{combine_bundle_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
+
+        def _separate_bundle_items(self,
+            separate_bundle_items: bpy.types.NodeSeparateBundleItems,
+            separate_bundle_items_str : str,
+        ) -> None:
+            self._write(f"{separate_bundle_items_str}.clear()")
+            for i, item in enumerate(separate_bundle_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{separate_bundle_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                item_str = f"{separate_bundle_items_str}[{i}]"
+
+                structure_type = enum_to_py_str(item.structure_type)
+                self._write(f"{item_str}.structure_type = {structure_type}")
 
 
     def _set_parents(self, node_tree: NodeTree) -> None:

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -635,12 +635,19 @@ class NTP_Operator(Operator):
                     return
             if type(socket_interface) == bpy.types.NodeTreeInterfaceSocketColor:
                 dv = vec4_to_py_str(dv)
-            elif type(dv) in {mathutils.Vector, mathutils.Euler}:
+            elif type(dv) == mathutils.Euler:
                 dv = vec3_to_py_str(dv)
             elif type(dv) == bpy_prop_array:
                 dv = array_to_py_str(dv)
             elif type(dv) == str:
                 dv = str_to_py_str(dv)
+            elif type(dv) == mathutils.Vector:
+                if len(dv) == 2:
+                    dv = vec2_to_py_str(dv)
+                elif len(dv) == 3:
+                    dv = vec3_to_py_str(dv)
+                elif len(dv) == 4:
+                    dv = vec4_to_py_str(dv)
             self._write(f"{socket_var}.default_value = {dv}")
 
             # min value

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -481,7 +481,7 @@ class NTP_Operator(Operator):
             elif st == ST.COLOR_MANAGED_VIEW_SETTINGS:
                 pass
             elif st == ST.COMPOSITOR_FILE_OUTPUT_ITEMS:
-                pass
+                self._compositor_file_output_items(attr, setting_str)
             elif st == ST.EVALUATE_CLOSURE_INPUT_ITEMS:
                 self._evaluate_closure_input_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.EVALUATE_CLOSURE_OUTPUT_ITEMS:
@@ -1560,7 +1560,25 @@ class NTP_Operator(Operator):
                 
                 # Uncomment when https://projects.blender.org/blender/blender/issues/147907 is resolved
                 #self._write(f"{items_str}.auto_remove = {item.auto_remove}")
-
+        
+        def _compositor_file_output_items(self,
+            compositor_file_output_items: bpy.types.NodeCompositorFileOutputItems,
+            compositor_file_output_items_str : str,
+        ) -> None:
+            self._write(f"{compositor_file_output_items_str}.clear()")
+            for i, item in enumerate(compositor_file_output_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{compositor_file_output_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                items_str = f"{compositor_file_output_items_str}[{i}]"
+                
+                self._write(f"{items_str}.override_node_format = {item.override_node_format}")
+                self._write(f"{items_str}.save_as_render = {item.save_as_render}")
+                if item.socket_type == 'VECTOR':
+                    self._write(f"{items_str}.vector_socket_dimensions = "
+                                f"{item.vector_socket_dimensions}")
 
     def _set_parents(self, node_tree: NodeTree) -> None:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -489,7 +489,7 @@ class NTP_Operator(Operator):
             elif st == ST.FIELD_TO_GRID_ITEMS:
                 self._field_to_grid_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.GEOMETRY_VIEWER_ITEMS:
-                pass
+                self._geometry_viewer_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.COMBINE_BUNDLE_ITEMS:
                 self._combine_bundle_items(attr, f"{node_var}.{attr_name}")
             elif st == ST.SEPARATE_BUNDLE_ITEMS:
@@ -1545,6 +1545,22 @@ class NTP_Operator(Operator):
                 self._write((f"{field_to_grid_items_str}.new("
                              f"{data_type}, {name_str})"))
                 
+        def _geometry_viewer_items(self,
+            geometry_viewer_items: bpy.types.NodeGeometryViewerItems,
+            geometry_viewer_items_str : str,
+        ) -> None:
+            self._write(f"{geometry_viewer_items_str}.clear()")
+            for i, item in enumerate(geometry_viewer_items):
+                socket_type = enum_to_py_str(item.socket_type)
+                name_str = str_to_py_str(item.name)
+                self._write((f"{geometry_viewer_items_str}.new("
+                             f"{socket_type}, {name_str})"))
+                
+                items_str = f"{geometry_viewer_items_str}[{i}]"
+                
+                # Uncomment when https://projects.blender.org/blender/blender/issues/147907 is resolved
+                #self._write(f"{items_str}.auto_remove = {item.auto_remove}")
+
 
     def _set_parents(self, node_tree: NodeTree) -> None:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -477,9 +477,9 @@ class NTP_Operator(Operator):
             elif st == ST.CLOSURE_OUTPUT_ITEMS:
                 self._closure_output_items(attr, setting_str)
             elif st == ST.COLOR_MANAGED_DISPLAY_SETTINGS:
-                pass
+                self._color_managed_display_settings(attr, setting_str)
             elif st == ST.COLOR_MANAGED_VIEW_SETTINGS:
-                pass
+                self._color_managed_view_settings(attr, setting_str)
             elif st == ST.COMPOSITOR_FILE_OUTPUT_ITEMS:
                 self._compositor_file_output_items(attr, setting_str)
             elif st == ST.EVALUATE_CLOSURE_INPUT_ITEMS:
@@ -1579,6 +1579,27 @@ class NTP_Operator(Operator):
                 if item.socket_type == 'VECTOR':
                     self._write(f"{items_str}.vector_socket_dimensions = "
                                 f"{item.vector_socket_dimensions}")
+                    
+        def _color_managed_display_settings(self,
+            display_settings : bpy.types.ColorManagedDisplaySettings,
+            display_settings_str : str
+        ) -> None:
+            device_str = enum_to_py_str(display_settings.display_device)
+            self._write(f"{display_settings_str}.display_device = {device_str}")
+            emulation_str = enum_to_py_str(display_settings.emulation)
+            self._write(f"{display_settings_str}.emulation = {emulation_str}")
+    
+        def _color_managed_view_settings(self,
+            view_settings : bpy.types.ColorManagedViewSettings,
+            view_settings_str : str
+        ) -> None:
+            # view transform must go before setting look
+            view_transform_str = enum_to_py_str(view_settings.view_transform)
+            self._write(f"{view_settings_str}.view_transform = {view_transform_str}")
+
+            look_str = enum_to_py_str(view_settings.look)
+            self._write(f"{view_settings_str}.look = {look_str}")
+
 
     def _set_parents(self, node_tree: NodeTree) -> None:
         """

--- a/NodeToPython/shader/__init__.py
+++ b/NodeToPython/shader/__init__.py
@@ -1,14 +1,17 @@
 if "bpy" in locals():
     import importlib
+    importlib.reload(node_tree)
     importlib.reload(operator)
     importlib.reload(ui)
 else:
+    from . import node_tree
     from . import operator
     from . import ui
 
 import bpy
 
 modules = [
+    node_tree,
     operator
 ]
 modules += ui.modules

--- a/NodeToPython/shader/node_tree.py
+++ b/NodeToPython/shader/node_tree.py
@@ -1,0 +1,11 @@
+import bpy
+
+from ..ntp_node_tree import NTP_NodeTree
+
+class NTP_ShaderNodeTree(NTP_NodeTree):
+    def __init__(self, node_tree: bpy.types.ShaderNodeTree, var: str):
+        super().__init__(node_tree, var)
+        self.zone_inputs: dict[str, list[bpy.types.Node]] = {}
+        if bpy.app.version >= (5, 0, 0):
+            self.zone_inputs["GeometryNodeRepeatInput"] = []
+            self.zone_inputs["NodeClosureInput"] = []

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -30,7 +30,8 @@ class NTP_OT_Shader(NTP_Operator):
     def _create_material(self, indent_level: int):
         self._write(f"{MAT_VAR} = bpy.data.materials.new("
                     f"name = {str_to_py_str(self.material_name)})", indent_level)
-        self._write(f"{MAT_VAR}.use_nodes = True\n\n", indent_level)
+        self._write("if bpy.app.version < (5, 0, 0):", indent_level)
+        self._write(f"{MAT_VAR}.use_nodes = True\n\n", indent_level + 1)
 
     def _initialize_shader_node_tree(self, ntp_node_tree: NTP_ShaderNodeTree, 
                                     nt_name: str) -> None:

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -6,7 +6,7 @@ from io import StringIO
 
 from ..utils import *
 from ..ntp_operator import NTP_Operator
-from ..ntp_node_tree import NTP_NodeTree
+from .node_tree import NTP_ShaderNodeTree
 from ..node_settings import node_settings
 
 MAT_VAR = "mat"
@@ -32,13 +32,13 @@ class NTP_OT_Shader(NTP_Operator):
                     f"name = {str_to_py_str(self.material_name)})", indent_level)
         self._write(f"{MAT_VAR}.use_nodes = True\n\n", indent_level)
 
-    def _initialize_shader_node_tree(self, ntp_node_tree: NTP_NodeTree, 
+    def _initialize_shader_node_tree(self, ntp_node_tree: NTP_ShaderNodeTree, 
                                     nt_name: str) -> None:
         """
         Initialize the shader node group
 
         Parameters:
-        ntp_node_tree (NTP_NodeTree): node tree to be generated and 
+        ntp_node_tree (NTP_ShaderNodeTree): node tree to be generated and 
             variable to use
         nt_name (str): name to use for the node tree
         """
@@ -56,13 +56,13 @@ class NTP_OT_Shader(NTP_Operator):
                          f"name = {str_to_py_str(nt_name)})"))
             self._write("", 0)
 
-    def _process_node(self, node: Node, ntp_nt: NTP_NodeTree) -> None:
+    def _process_node(self, node: Node, ntp_nt: NTP_ShaderNodeTree) -> None:
         """
         Create node and set settings, defaults, and cosmetics
 
         Parameters:
         node (Node): node to process
-        ntp_nt (NTP_NodeTree): the node tree that node belongs to
+        ntp_nt (NTP_ShaderNodeTree): the node tree that node belongs to
         """
         node_var: str = self._create_node(node, ntp_nt.var)
         self._set_settings_defaults(node)
@@ -75,9 +75,37 @@ class NTP_OT_Shader(NTP_Operator):
             elif node.bl_idname == 'NodeGroupOutput' and not ntp_nt.outputs_set:
                 self._group_io_settings(node, "output", ntp_nt)
                 ntp_nt.outputs_set = True
+        
+        if node.bl_idname in ntp_nt.zone_inputs:
+            ntp_nt.zone_inputs[node.bl_idname].append(node)
 
         self._hide_hidden_sockets(node)
-        self._set_socket_defaults(node)
+        if node.bl_idname not in ntp_nt.zone_inputs:
+            self._set_socket_defaults(node)
+
+    if bpy.app.version >= (5, 0, 0):
+        def _process_zones(self, zone_input_list: list[bpy.types.Node]) -> None:
+            """
+            Recreates a zone
+            zone_input_list (list[bpy.types.Node]): list of zone input 
+                nodes
+            """
+            for input_node in zone_input_list:
+                zone_output = input_node.paired_output
+
+                zone_input_var = self._node_vars[input_node]
+                zone_output_var = self._node_vars[zone_output]
+
+                self._write(f"# Process zone input {input_node.name}")
+                self._write(f"{zone_input_var}.pair_with_output"
+                            f"({zone_output_var})")
+
+                #must set defaults after paired with output
+                self._set_socket_defaults(input_node)
+                self._set_socket_defaults(zone_output)
+
+            if zone_input_list:
+                self._write("", 0)
 
     def _process_node_tree(self, node_tree: ShaderNodeTree) -> None:
         """
@@ -98,7 +126,7 @@ class NTP_OT_Shader(NTP_Operator):
 
         self._node_tree_vars[node_tree] = nt_var
 
-        ntp_nt = NTP_NodeTree(node_tree, nt_var)
+        ntp_nt = NTP_ShaderNodeTree(node_tree, nt_var)
 
         self._initialize_shader_node_tree(ntp_nt, nt_name)
 
@@ -109,9 +137,11 @@ class NTP_OT_Shader(NTP_Operator):
 
         #initialize nodes
         self._write(f"# Initialize {nt_var} nodes\n")
-
         for node in node_tree.nodes:
             self._process_node(node, ntp_nt)
+
+        for zone_list in ntp_nt.zone_inputs.values():
+            self._process_zones(zone_list)
 
         #set look of nodes
         self._set_parents(node_tree)

--- a/tools/node_settings_generator/types_utils.py
+++ b/tools/node_settings_generator/types_utils.py
@@ -21,18 +21,29 @@ class ST(Enum):
     # Special settings
     BAKE_ITEMS                           = auto()
     CAPTURE_ATTRIBUTE_ITEMS              = auto()
+    CLOSURE_INPUT_ITEMS                  = auto()
+    CLOSURE_OUTPUT_ITEMS                 = auto()
+    COLOR_MANAGED_DISPLAY_SETTINGS       = auto()
+    COLOR_MANAGED_VIEW_SETTINGS          = auto()
     COLOR_RAMP                           = auto()
+    COMBINE_BUNDLE_ITEMS                 = auto()
+    COMPOSITOR_FILE_OUTPUT_ITEMS         = auto()
     CURVE_MAPPING                        = auto()
     ENUM_DEFINITION                      = auto()
     ENUM_ITEM                            = auto()
+    EVALUATE_CLOSURE_INPUT_ITEMS         = auto()
+    EVALUATE_CLOSURE_OUTPUT_ITEMS        = auto()
+    FIELD_TO_GRID_ITEMS                  = auto()
     FOREACH_GEO_ELEMENT_GENERATION_ITEMS = auto()
     FOREACH_GEO_ELEMENT_INPUT_ITEMS      = auto()
     FOREACH_GEO_ELEMENT_MAIN_ITEMS       = auto()
     FORMAT_STRING_ITEMS                  = auto()
+    GEOMETRY_VIEWER_ITEMS                = auto()
     INDEX_SWITCH_ITEMS                   = auto()
     MENU_SWITCH_ITEMS                    = auto()
     NODE_TREE                            = auto()
     REPEAT_OUTPUT_ITEMS                  = auto()
+    SEPARATE_BUNDLE_ITEMS                = auto()
     SIM_OUTPUT_ITEMS                     = auto()
 
     # Image
@@ -59,22 +70,33 @@ class ST(Enum):
 READ_ONLY_TYPES : set[ST] = {
     ST.BAKE_ITEMS,
     ST.CAPTURE_ATTRIBUTE_ITEMS,
+    ST.CLOSURE_INPUT_ITEMS,
+    ST.CLOSURE_OUTPUT_ITEMS,
+    ST.COLOR_MANAGED_DISPLAY_SETTINGS,
+    ST.COLOR_MANAGED_VIEW_SETTINGS,
     ST.COLOR_RAMP,
+    ST.COMBINE_BUNDLE_ITEMS,
+    ST.COMPOSITOR_FILE_OUTPUT_ITEMS,
     ST.CRYPTOMATTE_ENTRIES,
     ST.CURVE_MAPPING,
     ST.ENUM_DEFINITION,
+    ST.EVALUATE_CLOSURE_INPUT_ITEMS,
+    ST.EVALUATE_CLOSURE_OUTPUT_ITEMS,
+    ST.FIELD_TO_GRID_ITEMS,
     ST.FILE_SLOTS,
     ST.FOREACH_GEO_ELEMENT_GENERATION_ITEMS,
     ST.FOREACH_GEO_ELEMENT_INPUT_ITEMS,
     ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS,
     ST.FORMAT_STRING_ITEMS,
+    ST.GEOMETRY_VIEWER_ITEMS,
     ST.IMAGE_FORMAT_SETTINGS,
     ST.IMAGE_USER,
     ST.INDEX_SWITCH_ITEMS,
     ST.LAYER_SLOTS,
     ST.MENU_SWITCH_ITEMS,
     ST.REPEAT_OUTPUT_ITEMS,
-    ST.SIM_OUTPUT_ITEMS,
+    ST.SEPARATE_BUNDLE_ITEMS,
+    ST.SIM_OUTPUT_ITEMS
 } 
 
 doc_to_NTP_type_dict : dict[str, ST | None] = {
@@ -82,6 +104,8 @@ doc_to_NTP_type_dict : dict[str, ST | None] = {
     "bpy_prop_collection of CryptomatteEntry": ST.CRYPTOMATTE_ENTRIES,
     "boolean" : ST.BOOL,
     "Collection" : ST.COLLECTION,
+    "ColorManagedDisplaySettings" : ST.COLOR_MANAGED_DISPLAY_SETTINGS,
+    "ColorManagedViewSettings" : ST.COLOR_MANAGED_VIEW_SETTINGS,
     "ColorMapping" : None, # Always read-only
     "ColorRamp" : ST.COLOR_RAMP,
     "CompositorNodeOutputFileFileSlots" : ST.FILE_SLOTS,
@@ -94,6 +118,7 @@ doc_to_NTP_type_dict : dict[str, ST | None] = {
     "float array of 2" : ST.VEC2,
     "float array of 3" : ST.VEC3,
     "float array of 4" : ST.VEC4,
+    "GeometryNodeFieldToGridItems" : ST.FIELD_TO_GRID_ITEMS,
     "Image" : ST.IMAGE,
     "ImageFormatSettings" : ST.IMAGE_FORMAT_SETTINGS,
     "ImageUser" : ST.IMAGE_USER,
@@ -106,8 +131,14 @@ doc_to_NTP_type_dict : dict[str, ST | None] = {
     "MovieClip" : ST.MOVIE_CLIP,
     "Node" : None, # (<4.2) Always used with zone inputs, need to make sure 
                    # output nodes exist. Handled separately from NTP attr system
+    "NodeClosureInputItems" : ST.CLOSURE_INPUT_ITEMS,
+    "NodeClosureOutputItems" : ST.CLOSURE_OUTPUT_ITEMS,
+    "NodeCombineBundleItems" : ST.COMBINE_BUNDLE_ITEMS,
+    "NodeCompositorFileOutputItems" : ST.COMPOSITOR_FILE_OUTPUT_ITEMS,
     "NodeEnumDefinition" : ST.ENUM_DEFINITION,
     "NodeEnumItem" : ST.ENUM_ITEM,
+    "NodeEvaluateClosureInputItems" : ST.EVALUATE_CLOSURE_OUTPUT_ITEMS,
+    "NodeEvaluateClosureOutputItems" : ST.EVALUATE_CLOSURE_OUTPUT_ITEMS,
     "NodeFunctionFormatStringItems" : ST.FORMAT_STRING_ITEMS,
     "NodeGeometryBakeItems" : ST.BAKE_ITEMS,
     "NodeGeometryCaptureAttributeItems" : ST.CAPTURE_ATTRIBUTE_ITEMS,
@@ -116,8 +147,10 @@ doc_to_NTP_type_dict : dict[str, ST | None] = {
     "NodeGeometryForeachGeometryElementMainItems": ST.FOREACH_GEO_ELEMENT_MAIN_ITEMS,
     "NodeGeometryRepeatOutputItems" : ST.REPEAT_OUTPUT_ITEMS,
     "NodeGeometrySimulationOutputItems" : ST.SIM_OUTPUT_ITEMS,
+    "NodeGeometryViewerItems" : ST.GEOMETRY_VIEWER_ITEMS,
     "NodeIndexSwitchItems" : ST.INDEX_SWITCH_ITEMS,
     "NodeMenuSwitchItems" : ST.MENU_SWITCH_ITEMS,
+    "NodeSeparateBundleItems" : ST.SEPARATE_BUNDLE_ITEMS,
     "NodeTree" : ST.NODE_TREE,
     "Object" : ST.OBJECT,
     "ParticleSystem" : ST.PARTICLE_SYSTEM,


### PR DESCRIPTION
# Issues
* https://github.com/BrendanParmer/NodeToPython/issues/171

# Changes
## Features
* Updated node settings for 5.0
* Scenes now use `compositing_node_group` instead of `node_tree`
* Added closure zone support
* Added repeat and closure zone support to shader node trees
* Bundles support
* Field to Grid support
* Handle new geometry viewer items
* Handle compositor file output items
* Handle Convert to Display node settings
* Support optional label socket attribute
* Geometry node trees can now set `use_wait_for_click` and `show_modifier_manager_panel` flags
* `material.use_nodes` is now only set in versions before Blender 5.0

## Fixes
* Vector dimensions for node tree default sockets are now properly handled (TODO: hotfix for 3.5.2?)
* Corrected some type hints

## Other
* New generated scenes are now created from a blank slate, rather than copying the current scene 
* Use `settings_str` instead of redefining in each conditional block
* Renamed some variables

## Tools
* Added new setting types
    * `CLOSURE_INPUT_ITEMS`
    * `CLOSURE_OUTPUT_ITEMS`
    * `COLOR_MANAGED_DISPLAY_SETTINGS`
    * `COLOR_MANAGED_VIEW_SETTINGS`
    * `COMBINE_BUNDLE_ITEMS`
    * `COMPOSITOR_FILE_OUTPUT_ITEMS`
    * `EVALUATE_CLOSURE_INPUT_ITEMS`
    * `EVALUATE_CLOSURE_OUTPUT_ITEMS`
    * `FIELD_TO_GRID_ITEMS`
    * `GEOMETRY_VIEWER_ITEMS` 
    * `SEPARATE_BUNDLE_ITEMS`