### PR TITLE
Essential node groups

### DIFF
--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -254,7 +254,8 @@ class NTP_OT_Compositor(NTP_Operator):
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
 
-            self._create_header(self.compositor_name)
+            self._create_bl_info(self.compositor_name)
+            self._create_imports()
             self._class_name = clean_string(self.compositor_name, lower=False)
             self._init_operator(comp_var, self.compositor_name)
 
@@ -262,7 +263,7 @@ class NTP_OT_Compositor(NTP_Operator):
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy\nimport mathutils\n\n\n")
+                self._create_imports()
 
         if self.is_scene:
             if self._mode == 'ADDON':

--- a/NodeToPython/compositor/operator.py
+++ b/NodeToPython/compositor/operator.py
@@ -274,6 +274,8 @@ class NTP_OT_Compositor(NTP_Operator):
 
         node_trees_to_process = self._topological_sort(self._base_node_tree)
 
+        self._import_essential_libs()
+
         for node_tree in node_trees_to_process:  
             self._process_node_tree(node_tree)
 

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -196,14 +196,15 @@ class NTP_OT_GeometryNodes(NTP_Operator):
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
             
-            self._create_header(nt.name)
+            self._create_bl_info(nt.name)
+            self._create_imports()
             self._class_name = clean_string(nt.name, lower = False)
             self._init_operator(nt_var, nt.name)
             self._write("def execute(self, context):", 1)
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy\nimport mathutils\n\n\n")
+                self._create_imports()
 
 
         node_trees_to_process = self._topological_sort(nt)

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -113,7 +113,7 @@ class NTP_OT_GeometryNodes(NTP_Operator):
                     
             if bpy.app.version >= (5, 0, 0):
                 if node_tree.show_modifier_manage_panel:
-                    self._write(f"{nt_var}.show_modifier_manager_panel = True")
+                    self._write(f"{nt_var}.show_modifier_manage_panel = True")
             self._write("", 0)
 
     def _process_node_tree(self, node_tree: GeometryNodeTree) -> None:

--- a/NodeToPython/geometry/operator.py
+++ b/NodeToPython/geometry/operator.py
@@ -209,6 +209,8 @@ class NTP_OT_GeometryNodes(NTP_Operator):
 
         node_trees_to_process = self._topological_sort(nt)
 
+        self._import_essential_libs()
+
         for node_tree in node_trees_to_process:  
             self._process_node_tree(node_tree)
 

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -290,6 +290,12 @@ class NTP_Operator(Operator):
                 for group_node in [node for node in nt.nodes
                                    if node.bl_idname == group_node_type]:
                     if group_node.node_tree not in visited:
+                        if group_node.node_tree is None:
+                            self.report(
+                                {'ERROR'}, 
+                                "NodeToPython: Found an invalid node tree. "
+                                "Are all data blocks valid?"
+                            )
                         dfs(group_node.node_tree)
                 result.append(nt)
         
@@ -1211,13 +1217,17 @@ class NTP_Operator(Operator):
         node_tree = getattr(node, attr_name)
         if node_tree is None:
             return
+        
         if node_tree in self._node_tree_vars:
             nt_var = self._node_tree_vars[node_tree]
             node_var = self._node_vars[node]
             self._write(f"{node_var}.{attr_name} = {nt_var}")
         else:
-            self.report({'WARNING'}, (f"NodeToPython: Node tree dependency graph " 
-                                    f"wasn't properly initialized"))
+            self.report(
+                {'WARNING'}, 
+                f"NodeToPython: Node tree dependency graph " 
+                f"wasn't properly initialized! Couldn't find "
+                f"node tree {node_tree.name}")
 
     def _save_image(self, img: bpy.types.Image) -> bool:
         """

--- a/NodeToPython/ntp_operator.py
+++ b/NodeToPython/ntp_operator.py
@@ -204,7 +204,7 @@ class NTP_Operator(Operator):
         
         return True
 
-    def _create_header(self, name: str) -> None:
+    def _create_bl_info(self, name: str) -> None:
         """
         Sets up the bl_info and imports the Blender API
 
@@ -228,9 +228,12 @@ class NTP_Operator(Operator):
             category = self._custom_category
         self._write(f"\"category\" : {str_to_py_str(category)},", 1)
         self._write("}\n", 0)
+
+    def _create_imports(self) -> None:
         self._write("import bpy", 0)
         self._write("import mathutils", 0)
-        self._write("import os\n", 0)
+        self._write("import os", 0)
+        self._write("\n", 0)
 
     def _init_operator(self, idname: str, label: str) -> None:
         """

--- a/NodeToPython/ntp_options.py
+++ b/NodeToPython/ntp_options.py
@@ -47,6 +47,12 @@ class NTP_PG_Options(bpy.types.PropertyGroup):
         default = 'SPACES_4'
     )
 
+    link_external_node_groups : bpy.props.BoolProperty(
+        name = "Link External Node Groups",
+        description="Simply tries to link external node groups, otherwise copies",
+        default = True
+    )
+
     if bpy.app.version >= (3, 4, 0):
         set_unavailable_defaults : bpy.props.BoolProperty(
             name = "Set unavailable defaults",

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -269,7 +269,8 @@ class NTP_OT_Shader(NTP_Operator):
 
             self._file = open(f"{self._addon_dir}/__init__.py", "w")
 
-            self._create_header(self.name)
+            self._create_bl_info(self.name)
+            self._create_imports()
             self._class_name = clean_string(self.name, lower=False)
             self._init_operator(self.obj_var, self.name)
 
@@ -277,7 +278,7 @@ class NTP_OT_Shader(NTP_Operator):
         else:
             self._file = StringIO("")
             if self._include_imports:
-                self._file.write("import bpy\nimport mathutils\n\n\n")
+                self._create_imports()
 
         if self.group_type == 'MATERIAL':
             self._create_material()

--- a/NodeToPython/shader/operator.py
+++ b/NodeToPython/shader/operator.py
@@ -291,6 +291,8 @@ class NTP_OT_Shader(NTP_Operator):
         
         node_trees_to_process = self._topological_sort(self._base_node_tree)
 
+        self._import_essential_libs()
+
         for node_tree in node_trees_to_process:
             self._process_node_tree(node_tree)
 

--- a/NodeToPython/ui/generation_settings.py
+++ b/NodeToPython/ui/generation_settings.py
@@ -27,7 +27,8 @@ class NTP_PT_GenerationSettings(bpy.types.Panel):
         generation_options = [
             "set_group_defaults",
             "set_node_sizes", 
-            "indentation_type"
+            "indentation_type",
+            "link_external_node_groups"
         ]
         if bpy.app.version >= (3, 4, 0):
             generation_options.append("set_unavailable_defaults")


### PR DESCRIPTION
# Changes
## Features
* Node groups from the essentials library are now simply linked by default, rather than automatically generating clutter (both in the generated code and the blend file) (#178)
    * This is a step forward in general library support
    * By default Blender seems to pack the essential node groups, so the generated ones don't look exactly the same in the UI. For 99% of users they should evaluate the same, for the other 1% please just make a local copy or something. I'm interested in feedback on this, and if there's a better way
        * I've chosen not to implement this with `bpy.ops.node.add_group_asset()`. I'd like to avoid NodeToPython needing to manage the context, and getting the `relative_asset_identifier` seems a little painful. 

## Fixes
* Typo with generated `GeometryNodeTree.show_modifier_manage_panel` attribute

## Other
* Better warning messages
* Separated out `bl_info` and `import` statement creation, allowing both add-on and script mode to use the same import statements