### PR TITLE
v4.0.1

### DIFF
--- a/NodeToPython/blender_manifest.toml
+++ b/NodeToPython/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "node_to_python"
-version = "4.0.0"
+version = "4.0.1"
 name = "Node To Python"
 tagline = "Turn node groups into Python code"
 maintainer = "Brendan Parmer <brendanparmer+nodetopython@gmail.com>"

--- a/NodeToPython/export/node_tree_exporter.py
+++ b/NodeToPython/export/node_tree_exporter.py
@@ -43,11 +43,14 @@ NO_DEFAULT_SOCKETS = {
     bpy.types.NodeTreeInterfaceSocketGeometry,
     bpy.types.NodeTreeInterfaceSocketImage,
     bpy.types.NodeTreeInterfaceSocketMaterial,
+    bpy.types.NodeTreeInterfaceSocketMatrix,
     bpy.types.NodeTreeInterfaceSocketObject,
     bpy.types.NodeTreeInterfaceSocketShader,
     bpy.types.NodeTreeInterfaceSocketTexture
 }
+
 if bpy.app.version >= (5, 0, 0):
+    NO_DEFAULT_SOCKETS.add(bpy.types.NodeTreeInterfaceSocketBundle)
     NO_DEFAULT_SOCKETS.add(bpy.types.NodeTreeInterfaceSocketClosure)
 
 #node input sockets that are messy to set default values for

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Node To Python automatically handles node layout, default values, subgroups, nam
 Blender's node-based editors are powerful, yet accessible tools, and I wanted to make scripting them easier for add-on creators. Combining Python with node based setups allows you to do things that would otherwise be tedious or impossible.
 
 ## Supported Versions
-NodeToPython v4.0.0 is supported for Blender 4.2 - 5.0 on Windows, macOS, and Linux
+NodeToPython v4.0.1 is supported for Blender 4.2 - 5.0 on Windows, macOS, and Linux
 * Some work is required to update NodeToPython for each Blender version, so experimental versions may not work properly and may even crash. 
 * New nodes, updated settings, and new node tree features require development to support. 
 * NodeToPython updates for new Blender versions usually doesn't start until the Beta phase of the release cycle


### PR DESCRIPTION
# Issues
* #190 

# Changes
* Adds `NodeTreeInterfaceSocketBundle` and `NodeTreeInterfaceSocketMatrix` to the list of types we don't attempt to set defaults for